### PR TITLE
[react-components] update `src/donation-link-with-utm.js`, pure func -> extends React.PureComponent

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ## Release
+### 7.0.8
+
+- [react-components] update `src/donation-link-with-utm.js`, pure func -> extends React.PureComponent
 
 ### 7.0.7
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/react-components",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "main": "lib/index.js",
   "repository": "https://github.com/twreporter/twreporter-npm-packages.git",
   "author": "twreporter <developer@twreporter.org>",

--- a/packages/react-components/src/donation-link-with-utm.js
+++ b/packages/react-components/src/donation-link-with-utm.js
@@ -4,45 +4,49 @@ import React from 'react'
 import url from 'url'
 import externalLinks from '@twreporter/core/lib/constants/external-links'
 
-export default function DonationLinkWithUtm(props) {
-  const { children = null, utmMedium = '' } = props
-
-  const handleClick = e => {
-    e.preventDefault()
-
-    let donationURL = externalLinks.donation
-
-    try {
-      const utmSource = window.location.host
-      const utmCampaign = window.location.pathname
-      const parseQueryString = true
-      const urlObj = url.parse(donationURL, parseQueryString)
-
-      urlObj.query.utm_source = utmSource
-      urlObj.query.utm_medium = utmMedium
-      urlObj.query.utm_campaign = utmCampaign
-
-      donationURL = url.format(urlObj)
-    } catch (e) {
-      console.warn('Can not get donation url with utm param', e)
-    }
-
-    window.open(donationURL, 'DonationWindow')
+export default class DonationLinkWithUtm extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node,
+    utmMedium: PropTypes.string,
   }
 
-  return (
-    <a
-      href={externalLinks.donation}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={handleClick}
-    >
-      {children}
-    </a>
-  )
-}
+  state = {
+    isClient: false,
+  }
 
-DonationLinkWithUtm.propTypes = {
-  children: PropTypes.node,
-  utmMedium: PropTypes.string,
+  componentDidMount() {
+    this.setState({
+      isClient: true,
+    })
+  }
+
+  render() {
+    const { children, utmMedium } = this.props
+    const { isClient } = this.state
+    let donationURL = externalLinks.donation
+
+    if (isClient) {
+      // client side rendering
+      try {
+        const utmSource = window.location.host
+        const utmCampaign = window.location.pathname
+        const parseQueryString = true
+        const urlObj = url.parse(donationURL, parseQueryString)
+
+        urlObj.query.utm_source = utmSource
+        urlObj.query.utm_medium = utmMedium
+        urlObj.query.utm_campaign = utmCampaign
+
+        donationURL = url.format(urlObj)
+      } catch (e) {
+        console.warn('Can not get donation url with utm param', e)
+      }
+    }
+
+    return (
+      <a href={donationURL} target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    )
+  }
 }


### PR DESCRIPTION
### Reason to Change
Users might not click the donation link directly.
They might right click the donation link  and click `Open Link in New Tab` or `Open Link in New Window` ..., etc.
In previous implementation, we handle browser navigation on click event. However, it won't work if users does not left click the link.

### Change Log
Use `this.state.isClient` to update the donation link after mounting on client side.
