### PR TITLE
[react-article-components] `ff-tisa` for english text

### DIFF
--- a/packages/react-article-components/CHANGELOG.md
+++ b/packages/react-article-components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### 1.0.18
+
+- support new english text(ff-tisa) on typekit
+
 ## RELEASE
 
 ### 1.0.17

--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -28,6 +28,11 @@ const _ = {
   throttle,
 }
 
+const fontFamilyCss = css`
+  /* ff-tisa-web-prop is for english text */
+  font-family: ff-tisa-web-pro, source-han-sans-traditional, sans-serif;
+`
+
 const BorderBox = styled.div`
   * {
     box-sizing: border-box;
@@ -35,6 +40,8 @@ const BorderBox = styled.div`
 `
 
 const BackgroundBlock = styled(BorderBox)`
+  ${fontFamilyCss}
+
   /* pass from ThemeProvider */
   background-color: ${props => props.theme.colors.primary.background};
 

--- a/packages/react-article-components/src/components/body/brief.js
+++ b/packages/react-article-components/src/components/body/brief.js
@@ -15,7 +15,8 @@ const _ = {
 }
 
 const Content = styled.div`
-  font-family: source-han-serif-tc, serif;
+  /* ff-tisa-web-pro is for english text */
+  font-family: ff-tisa-web-pro, source-han-serif-tc, serif;
   p {
     color: ${props => props.theme.colors.base.lightText};
     line-height: 1.7;


### PR DESCRIPTION
### Kanbanflow Card
https://kanbanflow.com/t/2DQ6UGQE

### Typekit Setup
create a new project named `*.twreporter.org` in https://fonts.adobe.com/my_fonts#web_projects-section.

#### `*.twreporter.org` Project Details:
`ff-tisa-web-pro` (new added in this change)
- `Regular: 400`
- `Medium: 600`
- `Bold: 700`

`source-han-sans-tranditional`
- `ExtraLight: 100`
- `Normal: 300`
- `Bold: 700`

`source-han-serif-tc`
- `SemiBold: 600`

### Implementation Details For Notice
According to gina's mockup(https://zpl.io/2yPlg8q), `font-weight` of `ff-tisa` is different from  `source-han-sans-tranditional` (as you can see the differences above).

In current implementation, it is hard to set different `font-weight` on Chinese and English texts.
Therefore, we use `font-weight` of Chinese to send requests to typekit to get English texts.
We let typekit to do the fallback, typekit will try to get the closest value, such as `Regular: 400` if we send `Normal: 300` in the requests.