### PR TITLE
Make `center-small` alignment fills 100% viewport width on mobile

### DIFF
--- a/packages/react-article-components/CHANGELOG.md
+++ b/packages/react-article-components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### 1.0.20
+
+- make `center-small` alignment fills 100% viewport width on mobile
+
 ## RELEASE
 
 ### 1.0.19

--- a/packages/react-article-components/package.json
+++ b/packages/react-article-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/react-article-components",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "The Reporter react article components, which are used in article page",
   "main": "lib/components/article-page.js",
   "repository": "https://github.com/twreporter/twreporter-npm-packages.git",

--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -89,7 +89,6 @@ const BodyBackground = styled.div`
 const BodyBlock = styled.div`
   position: relative;
   width: 100%;
-  overflow: hidden;
   ${mq.desktopOnly`
     max-width: 1024px;
     margin: 0 auto;

--- a/packages/react-article-components/src/components/body/index.js
+++ b/packages/react-article-components/src/components/body/index.js
@@ -151,6 +151,12 @@ const StyledExtendImageBlock = styled.div`
 
 const StyledLargeImageBlock = styled.div`
   ${largeWidthCSS}
+
+  /* overwrite largeWidthCSS.mobile styles */
+  ${mq.mobileOnly`
+    width: 100%;
+  `}
+
   /* overwrite the position of image block and caption */
   margin-left: auto;
   margin-right: auto;

--- a/packages/react-article-components/src/components/body/index.js
+++ b/packages/react-article-components/src/components/body/index.js
@@ -142,6 +142,7 @@ const StyledHeaderTwo = styled(Headings.H2)`
 const StyledEmbedded = styled(Embedded)`
   ${largeWidthCSS}
   margin: ${mockup.margin.large};
+  overflow: hidden;
 `
 
 const StyledExtendImageBlock = styled.div`


### PR DESCRIPTION
### KanbanFlow Card
https://kanbanflow.com/t/2E4GmzdB

### Reason to Change
https://github.com/twreporter/twreporter-npm-packages/commit/011316536d030196293970b49dfc21bc88b25205 is to fix `image`, `slideshow` ...etc multimedia element not to fill 100% viewport width.