### PR TITLE
[react-article-components] fix embedded img not centered if not big enough

### DIFF
--- a/packages/react-article-components/CHANGELOG.md
+++ b/packages/react-article-components/CHANGELOG.md
@@ -14,6 +14,7 @@
 - provide `name` prop in styled.ThemeProvider
 - slideshow: adjust styles in photo theme
 - audio: style tuning
+- fix embedded img not centered if not big enough
 
 ## RELEASE
 

--- a/packages/react-article-components/src/components/body/embedded-code.js
+++ b/packages/react-article-components/src/components/body/embedded-code.js
@@ -15,6 +15,14 @@ const _ = {
 
 const Embedded = styled.div`
   position: relative;
+
+  /* styles for image link */
+  img.img-responsive {
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
 `
 
 const Caption = styled.div`


### PR DESCRIPTION
### KanbanFlow Card
https://kanbanflow.com/t/fp8ce375