### PR TITLE
[Bug] Disable `fireOnRapidScroll` in Waypoint of index page section to keep anchor correct

### DIFF
--- a/packages/index-page/CHANGELOG.md
+++ b/packages/index-page/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Release
 
+### 1.0.6-rc.2
+
+- Set `fireOnRapidScroll` attribute of `Waypoint` to false
+
 ### 1.0.6-rc.1
 
 #### Notable Changes

--- a/packages/index-page/package.json
+++ b/packages/index-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/index-page",
-  "version": "1.0.6-rc.1",
+  "version": "1.0.6-rc.2",
   "main": "lib/index.js",
   "repository": "https://github.com/twreporter/twreporter-npm-packages.git",
   "author": "twreporter <developer@twreporter.org>",

--- a/packages/index-page/src/components/animations/section-animation-wrapper.js
+++ b/packages/index-page/src/components/animations/section-animation-wrapper.js
@@ -42,7 +42,7 @@ const SectionAnimationWrapper = WrappedComponent => {
       return (
         <Waypoint
           onEnter={this.startScrollAnimation}
-          fireOnRapidScroll
+          fireOnRapidScroll={false}
           topOffset="80%"
           bottomOffset="19%"
         >


### PR DESCRIPTION
[Kanban Flow Card](https://kanbanflow.com/t/H9a4fnka)