### PR TITLE
[core] Use `request-origins.js` constants in `sigin-in-href.js` 

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### 1.1.2-rc.2
+
+#### Notable Changes
+
+- Use `request-origins.js` constants in `sigin-in-href.js`
+
+#### Commits
+
+- [[44816b0](https://github.com/twreporter/twreporter-npm-packages/commit/44816b05e05bb8941b8174ec056ed1a4f91446f6)] - Use `request-origins.js` constants in `sigin-in-href.js`(taylrj)
+
 ### 1.1.2-rc.1
 
 #### Notable Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/core",
-  "version": "1.1.2-rc.1",
+  "version": "1.1.2-rc.2",
   "main": "lib/index.js",
   "repository": "https://github.com/twreporter/twreporter-npm-packages.git",
   "author": "twreporter <developer@twreporter.org>",

--- a/packages/core/src/utils/sign-in-href.js
+++ b/packages/core/src/utils/sign-in-href.js
@@ -1,3 +1,4 @@
+import requestOrigins from '../constants/request-origins'
 import { getGlobalEnv } from './global-env'
 
 const { releaseBranch } = getGlobalEnv()
@@ -6,36 +7,12 @@ const signInSearchKeys = {
   destination: 'destination',
 }
 const signInPathname = '/signin'
-const signInHref = {
-  master: {
-    protocol: 'http',
-    host: 'localhost:3030',
-    pathname: signInPathname,
-    searchKeys: signInSearchKeys,
-  },
-  preview: {
-    protocol: 'https',
-    host: 'staging-accounts.twreporter.org',
-    pathname: signInPathname,
-    searchKeys: signInSearchKeys,
-  },
-  staging: {
-    protocol: 'https',
-    host: 'staging-accounts.twreporter.org',
-    pathname: signInPathname,
-    searchKeys: signInSearchKeys,
-  },
-  release: {
-    protocol: 'https',
-    host: 'accounts.twreporter.org',
-    pathname: signInPathname,
-    searchKeys: signInSearchKeys,
-  },
-}[releaseBranch]
 
 export function getSignInHref(destination = '') {
+  const signInOrigin =
+    requestOrigins.forClientSideRendering[releaseBranch].accounts
   const currentHrefSearch = destination
-    ? `?${signInHref.searchKeys.destination}=${destination}`
+    ? `?${signInSearchKeys.destination}=${destination}`
     : ''
-  return `${signInHref.protocol}://${signInHref.host}${signInHref.pathname}${currentHrefSearch}`
+  return `${signInOrigin}${signInPathname}${currentHrefSearch}`
 }

--- a/packages/index-page/CHANGELOG.md
+++ b/packages/index-page/CHANGELOG.md
@@ -4,9 +4,24 @@
 
 ## Release
 
+### 1.0.6-rc.3
+
+#### Notable Changes
+
+- dep upgrade:
+  - @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2
+
+#### Commits
+
+- [[d6f4a42](https://github.com/twreporter/twreporter-npm-packages/pull/68/commits/d6f4a42d1fd5f830e7cf2091cbe1197f4bc03d50)] - [index-page] @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
+
 ### 1.0.6-rc.2
 
 - Set `fireOnRapidScroll` attribute of `Waypoint` to false
+
+#### Commits
+
+- [[2858cb4](https://github.com/twreporter/twreporter-npm-packages/commit/2858cb40d52917d58228418dbf58b8156f3388a3)] - [index-page] Set `fireOnRapidScroll` attribute of `Waypoint` to false(taylrj)
 
 ### 1.0.6-rc.1
 

--- a/packages/index-page/CHANGELOG.md
+++ b/packages/index-page/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 #### Commits
 
-- [[d6f4a42](https://github.com/twreporter/twreporter-npm-packages/pull/68/commits/d6f4a42d1fd5f830e7cf2091cbe1197f4bc03d50)] - [index-page] @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
+- [[e4df8a8](https://github.com/twreporter/twreporter-npm-packages/commit/e4df8a85c71d48570196e55c389b9b455c8dbd39)] - [index-page] @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
 
 ### 1.0.6-rc.2
 

--- a/packages/index-page/package.json
+++ b/packages/index-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/index-page",
-  "version": "1.0.6-rc.2",
+  "version": "1.0.6-rc.3",
   "main": "lib/index.js",
   "repository": "https://github.com/twreporter/twreporter-npm-packages.git",
   "author": "twreporter <developer@twreporter.org>",

--- a/packages/index-page/package.json
+++ b/packages/index-page/package.json
@@ -10,7 +10,7 @@
     "dev": "make dev"
   },
   "dependencies": {
-    "@twreporter/core": "1.1.2-rc.1",
+    "@twreporter/core": "1.1.2-rc.2",
     "lodash": "^4.0.0",
     "prop-types": "^15.0.0",
     "react": "^16.3.0",

--- a/packages/react-article-components/CHANGELOG.md
+++ b/packages/react-article-components/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## RELEASE
 
+### 1.0.26-rc.2
+
+#### Notable Changes
+
+- dep upgrade:
+  - @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2
+  - @twreporter/react-components: 8.0.3-rc.1 -> 8.0.3-rc.2
+  - @twreporter/universal-header": 2.1.2-rc.2 -> 2.1.2-rc.3
+
+#### Commits
+
+- [[ac2e03a](https://github.com/twreporter/twreporter-npm-packages/commit/ac2e03ab52df3e6e9dc34b33c05e21bb3ceeb223)] - @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
+- [[7dcb2a0](https://github.com/twreporter/twreporter-npm-packages/commit/7dcb2a0b90295db67092955bff9fecbf7551a714)] - @twreporter/universal-header: 2.1.2-rc.2 -> 2.1.2-rc.3 (taylrj)
+- [[e0edf3c](https://github.com/twreporter/twreporter-npm-packages/commit/e0edf3c1c3aa21ada3717d89a0a432e288deaf56)] - @twreporter/react-components: 8.0.3-rc.1 -> 8.0.3-rc.2 (taylrj)
+
 ### 1.0.26-rc.1
 
 #### Notable Changes

--- a/packages/react-article-components/package.json
+++ b/packages/react-article-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/react-article-components",
-  "version": "1.0.26-rc.1",
+  "version": "1.0.26-rc.2",
   "description": "The Reporter react article components, which are used in article page",
   "main": "lib/components/article-page.js",
   "repository": "https://github.com/twreporter/twreporter-npm-packages.git",

--- a/packages/react-article-components/package.json
+++ b/packages/react-article-components/package.json
@@ -23,9 +23,9 @@
   },
   "dependencies": {
     "@twreporter/core": "1.1.2-rc.1",
-    "@twreporter/react-components": "^8.0.2",
+    "@twreporter/react-components": "8.0.3-rc.1",
     "@twreporter/redux": "^5.0.4",
-    "@twreporter/universal-header": "^2.1.1",
+    "@twreporter/universal-header": "2.1.2-rc.2",
     "howler": "^2.1.1",
     "lodash": "^4.17.11",
     "memoize-one": "^5.0.5",

--- a/packages/react-article-components/package.json
+++ b/packages/react-article-components/package.json
@@ -22,7 +22,7 @@
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {
-    "@twreporter/core": "1.1.2-rc.1",
+    "@twreporter/core": "1.1.2-rc.2",
     "@twreporter/react-components": "8.0.3-rc.1",
     "@twreporter/redux": "^5.0.4",
     "@twreporter/universal-header": "2.1.2-rc.2",

--- a/packages/react-article-components/package.json
+++ b/packages/react-article-components/package.json
@@ -25,7 +25,7 @@
     "@twreporter/core": "1.1.2-rc.2",
     "@twreporter/react-components": "8.0.3-rc.1",
     "@twreporter/redux": "^5.0.4",
-    "@twreporter/universal-header": "2.1.2-rc.2",
+    "@twreporter/universal-header": "2.1.2-rc.3",
     "howler": "^2.1.1",
     "lodash": "^4.17.11",
     "memoize-one": "^5.0.5",

--- a/packages/react-article-components/package.json
+++ b/packages/react-article-components/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@twreporter/core": "1.1.2-rc.2",
-    "@twreporter/react-components": "8.0.3-rc.1",
+    "@twreporter/react-components": "8.0.3-rc.2",
     "@twreporter/redux": "^5.0.4",
     "@twreporter/universal-header": "2.1.2-rc.3",
     "howler": "^2.1.1",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## Release
 
+### 8.0.3-rc.2
+
+#### Notable Changes
+
+- dep upgrade:
+  - @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2
+
+#### Commits
+
+- [[3eb434d](https://github.com/twreporter/twreporter-npm-packages/commit/3eb434ddb8ab3ee148a413a7e42b7925d6ca5a27)] - @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
+
 ### 8.0.3-rc.1
 
 #### Notable Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -10,7 +10,7 @@
     "dev": "make dev"
   },
   "dependencies": {
-    "@twreporter/core": "1.1.2-rc.1",
+    "@twreporter/core": "1.1.2-rc.2",
     "@twreporter/redux": "^5.0.4",
     "hoist-non-react-statics": "^2.3.1",
     "lodash": "^4.0.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/react-components",
-  "version": "8.0.3-rc.1",
+  "version": "8.0.3-rc.2",
   "main": "lib/index.js",
   "repository": "https://github.com/twreporter/twreporter-npm-packages.git",
   "author": "twreporter <developer@twreporter.org>",

--- a/packages/universal-header/CHANGELOG.md
+++ b/packages/universal-header/CHANGELOG.md
@@ -4,13 +4,26 @@
 
 ## Released
 
+### 2.1.2-rc.3
+
+- dep upgrade:
+  - @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2
+
+#### Commits
+
+- [[0f3751e](https://github.com/twreporter/twreporter-npm-packages/pull/68/commits/0f3751ed840085525cd6c6af6e6ac9f8385a1ed7)] - [universal-header] upgrade @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
+
+#### Commits
+
+- [[72ff7f5](https://github.com/twreporter/twreporter-npm-packages/pull/63/commits/72ff7f5dd50798da5115d635a56f30c48be16509)] - [universal-header] Update constant of `categories` in `channelPathnames` (taylrj)
+
 ### 2.1.2-rc.2
 
 - Update `categories` in `channelPathnames` from `/?section=categories` to `/#categories`
 
 #### Commits
 
-- [[72ff7f5](https://github.com/twreporter/twreporter-npm-packages/pull/63/commits/72ff7f5dd50798da5115d635a56f30c48be16509)] - [universal-header] Update constant of `categories` in `channelPathnames` (taylrj)
+- [[1f14b29](https://github.com/twreporter/twreporter-npm-packages/commit/1f14b29912ae703bfea7ea55725f57abdfaf314e)] - [universal-header] Update constant of `categories` in `channelPathnames` (taylrj)
 
 ### 2.1.2-rc.1
 

--- a/packages/universal-header/CHANGELOG.md
+++ b/packages/universal-header/CHANGELOG.md
@@ -11,11 +11,11 @@
 
 #### Commits
 
-- [[0f3751e](https://github.com/twreporter/twreporter-npm-packages/pull/68/commits/0f3751ed840085525cd6c6af6e6ac9f8385a1ed7)] - [universal-header] upgrade @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
+- [[a5ad626](https://github.com/twreporter/twreporter-npm-packages/commit/a5ad626229ad995150c3beb0d26d2e6a70254a84)] - [universal-header] upgrade @twreporter/core: 1.1.2-rc.1 -> 1.1.2-rc.2(taylrj)
 
 #### Commits
 
-- [[72ff7f5](https://github.com/twreporter/twreporter-npm-packages/pull/63/commits/72ff7f5dd50798da5115d635a56f30c48be16509)] - [universal-header] Update constant of `categories` in `channelPathnames` (taylrj)
+- [[1f14b29](https://github.com/twreporter/twreporter-npm-packages/commit/1f14b29912ae703bfea7ea55725f57abdfaf314e)] - [universal-header] Update constant of `categories` in `channelPathnames` (taylrj)
 
 ### 2.1.2-rc.2
 

--- a/packages/universal-header/package.json
+++ b/packages/universal-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/universal-header",
-  "version": "2.1.2-rc.2",
+  "version": "2.1.2-rc.3",
   "description": "Universal header of TWReporter sites",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/universal-header/package.json
+++ b/packages/universal-header/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@twreporter/core": "1.1.2-rc.1",
+    "@twreporter/core": "1.1.2-rc.2",
     "@twreporter/redux": "^5.0.4",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
Problem description:

Since we are going to test on `next` release branch and `signInHref` in `sigin-in-href.js` doesn't have `next` branch as an attribute, font-end server crashes at [this line](https://github.com/twreporter/twreporter-npm-packages/blob/372554322a357cb2bef99f64586e376a13992b8b/packages/core/src/utils/sign-in-href.js#L38).

I propose to maintain only one constant file (`request-origins.js` ) to keep the origin information of different release branch.

Ref: [Kanban Flow Card](https://kanbanflow.com/t/BJCoy4EG)
