### PR TITLE
fix(universal-header): standalone header cannot work normally

### DIFF
--- a/packages/universal-header/package.json
+++ b/packages/universal-header/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "@twreporter/core": "^1.2.0",
-    "@twreporter/redux": "^6.0.1",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.2",
     "querystring": "^0.2.0",
@@ -27,6 +26,8 @@
     "react-redux": "^6.0.0",
     "react-router-dom": "^5.1.2",
     "react-transition-group": "^2.0.0",
+    "redux": "^4.0.1",
+    "redux-thunk": "^2.3.0",
     "styled-components": "^4.0.0"
   },
   "files": [

--- a/packages/universal-header/src/actions/auth.js
+++ b/packages/universal-header/src/actions/auth.js
@@ -1,0 +1,88 @@
+import actionTypes from '../constants/action-types'
+import axios from 'axios'
+import errorActionCreators from './error-action-creators'
+// lodash
+import get from 'lodash/get'
+
+const _ = {
+  get,
+}
+
+const timeout = 5000
+
+/**
+ *  Send POST method request with Cookie in the headers
+ *  to fetch the access_token.
+ *
+ *  @param {string} [cookieList] - cookieList contains `id_token` cookie
+ *  @return {Function} returned function will get executed by the Redux Thunk middleware
+ */
+export function getAccessToken(cookieList) {
+  /**
+   *  @param {Function} dispatch - Redux store dispatch function
+   *  @param {Function} getState - Redux store getState function
+   *  @return {Promise} resolve with success action and reject with fail action
+   */
+  return (dispatch, getState) => {
+    const state = getState()
+    const apiOrigin = _.get(state, 'origins.api', '')
+    const url = `${apiOrigin}/v2/auth/token`
+    const headers = {}
+
+    if (cookieList) {
+      headers.Cookie = cookieList
+    }
+
+    const options = {
+      timeout,
+      headers,
+      withCredentials: true,
+    }
+
+    const interceptor = axios.interceptors.request.use(config => {
+      const { method, url, headers, data, withCredentials, timeout } = config
+      dispatch({
+        type: actionTypes.REQUEST_AUTH,
+        payload: {
+          method,
+          config: {
+            timeout,
+            withCredentials,
+          },
+          url,
+          headers,
+          body: data,
+        },
+      })
+      axios.interceptors.request.eject(interceptor)
+      return config
+    })
+
+    return axios
+      .post(url, null, options)
+      .then(axiosRes => {
+        const successAction = {
+          type: actionTypes.AUTH_SUCCESS,
+          payload: {
+            headers: axiosRes.headers,
+            statusCode: axiosRes.status,
+            data: _.get(axiosRes, 'data.data'),
+          },
+        }
+        dispatch(successAction)
+        return successAction
+      })
+      .catch(err => {
+        const failAction = errorActionCreators.axios(
+          err,
+          actionTypes.AUTH_FAILURE
+        )
+        dispatch(failAction)
+        return Promise.reject(failAction)
+      })
+  }
+}
+
+export default {
+  getAccessToken,
+}

--- a/packages/universal-header/src/actions/error-action-creators.js
+++ b/packages/universal-header/src/actions/error-action-creators.js
@@ -1,0 +1,145 @@
+// lodash
+import get from 'lodash/get'
+import merge from 'lodash/merge'
+
+const _ = {
+  get,
+  merge,
+}
+
+/**
+ *  Refine Axios config to remain the infomative properties.
+ *  @param {Object} axiosConfig - config provied by Axios
+ *  @return {Object} - empty object or the object containing the following properties
+ *  'url',
+ *  'method' ,
+ *  'baseURL',
+ *  'headers',
+ *  'params',
+ *  'timeout',
+ *  'withCredentials',
+ *  'auth',
+ *  'responseType',
+ *  'responseEncoding',
+ *  'maxContentLength',
+ *  'proxy'
+ *
+ *  For other removed properties,
+ *  see https://github.com/axios/axios#request-config
+ */
+function refineAxiosConfig(axiosConfig) {
+  if (typeof axiosConfig === 'object' && axiosConfig !== null) {
+    return {
+      // request url
+      url: axiosConfig.url,
+      // requst method
+      method: axiosConfig.method,
+      // request baseURL
+      baseURL: axiosConfig.baseURL,
+      // request headers
+      headers: axiosConfig.headers,
+      // request query params
+      params: axiosConfig.params,
+      // request data
+      data: axiosConfig.data,
+      // request timeout
+      timeout: axiosConfig.timeout,
+      withCredentials: axiosConfig.withCredentials,
+      auth: axiosConfig.auth,
+      responseType: axiosConfig.responseType,
+      responseEncoding: axiosConfig.responseEncoding,
+      maxContentLength: axiosConfig.maxContentLength,
+      proxy: axiosConfig.proxy,
+    }
+  }
+
+  return {}
+}
+
+/**
+ *  Axios Error object
+ *  @typedef {Error} AxiosError
+ *  @property {Function} toJSON
+ *  @property {Object} config - Axios config
+ *  @property {Object} request - Axios request
+ *  @property {Object} response- Axios response
+ *  @property {bool} isAxiosError
+ *  @property {string} message - Error message
+ *  @property {string} stack - Error stack
+ */
+
+/**
+ *  Refined Axios error object type definition
+ *  We only pick certain properties of Axios error to log
+ *  because of the record size limitation (250kb) of
+ *  Stackdriver logging system.
+ *  @typedef {Error} RefinedAxiosError
+ *  @property {Object} config - Refined Axios config object
+ *  @property {Object} data - Server response body
+ *  @property {Object} headers - Server response headers
+ *  @property {number} statusCode - Response status code
+ *  @property {string} message - Error message
+ *  @property {string} name - Error name
+ */
+
+/**
+ *  Error rejected from Axios contains many details
+ *  which we might not need.
+ *  Therefore, we need to remove those properties
+ *  to maintain a neat and informative object.
+ *
+ *  @param {AxiosError} err - Axios Error object
+ *  @return {RefinedAxiosError}
+ */
+function refineAxiosError(err) {
+  const config = refineAxiosConfig(_.get(err, 'config'))
+  let data = null
+  let statusCode = 500 // internal server error
+  let headers = null
+  let message = _.get(err, 'message')
+
+  if (err.response) {
+    data = _.get(err, 'response.data')
+    statusCode = _.get(err, 'response.status')
+    headers = _.get(err, 'response.headers')
+  } else if (err.request) {
+    message = 'A request was made but no response was received: ' + message
+  } else {
+    message = 'An error occured when setting up the request: ' + message
+  }
+
+  const refinedErr = new Error(message)
+  refinedErr.name = 'AxiosError'
+  refinedErr.data = data
+  refinedErr.statusCode = statusCode
+  refinedErr.headers = headers
+  refinedErr.config = config
+
+  return refinedErr
+}
+
+/**
+ *  error action type definition
+ *  @typedef {Object} ErrorAction
+ *  @property {string} type - Action error type
+ *  @property {RefinedAxiosError} payload
+ */
+
+/**
+ *  Create an action which carefully records the details about the error.
+ *  @param {AxiosError} [err={}] - Axios Error
+ *  @param {string} failActionType
+ *  @returns {ErrorAction}
+ */
+function createAxiosErrorAction(err = {}, failActionType) {
+  return {
+    type: failActionType,
+    payload: {
+      error: refineAxiosError(err),
+    },
+  }
+}
+
+export default {
+  axios: createAxiosErrorAction,
+}

--- a/packages/universal-header/src/constants/action-types.js
+++ b/packages/universal-header/src/constants/action-types.js
@@ -1,0 +1,7 @@
+export default {
+  // auth
+  REQUEST_AUTH: 'request_authorization',
+  AUTH_SUCCESS: 'grant_authorization_success',
+  AUTH_FAILURE: 'grant_authorization_failure',
+  AUTH_CLEAR: 'clear_authorization',
+}

--- a/packages/universal-header/src/reducers/auth.js
+++ b/packages/universal-header/src/reducers/auth.js
@@ -1,0 +1,85 @@
+import actionTypes from '../constants/action-types'
+import jwtUtils from '../utils/jwt'
+// lodash
+import get from 'lodash/get'
+
+const _ = {
+  get,
+}
+
+const initState = {
+  accessToken: '',
+  actionType: '',
+  lastAction: null,
+  isAuthed: false,
+  isRequesting: false,
+  userInfo: null,
+}
+
+/**
+ *  @param {Object} state - redux state
+ *  @param {bool} state.isRequesting - requst is in progress
+ *  @param {bool} state.isAuthed - indicates if authorization succeeds
+ *  @param {Object} state.lastAction - last redux action for debugging
+ *  @param {string} state.lastAction.actionType
+ *  @param {Object} state.lastAction.actionPayload
+ *  @param {Object} state.userInfo - user information
+ *  @param {number} state.userInfo.user_id - id of user
+ *  @param {string} state.userInfo.jwt - access_token granted for the user
+ *  @param {string} state.userInfo.email - email of the user
+ *  @param {Object} action - redux action
+ *  @param {string} action.type
+ *  @param {Object} action.payload - response of API server
+ *  @param {string} action.payload.url - request endpoint
+ *  @param {Object} action.payload.options - request options
+ *  @param {string} action.payload.message - error message
+ */
+export default function auth(state = initState, action) {
+  switch (action.type) {
+    case actionTypes.AUTH_CLEAR: {
+      // return empty state
+      return initState
+    }
+    case actionTypes.REQUEST_AUTH: {
+      return {
+        accessToken: initState.accessToken,
+        lastAction: {
+          type: action.type,
+          payload: action.payload,
+        },
+        isAuthed: false,
+        isRequesting: true,
+        userInfo: initState.userInfo,
+      }
+    }
+    case actionTypes.AUTH_FAILURE: {
+      return {
+        accessToken: initState.accessToken,
+        lastAction: {
+          type: action.type,
+          payload: action.payload,
+        },
+        isAuthed: false,
+        isRequesting: false,
+        userInfo: initState.userInfo,
+      }
+    }
+    case actionTypes.AUTH_SUCCESS: {
+      const jwt = _.get(action, 'payload.data.jwt', '')
+      const userInfo = jwtUtils.decodePayload(jwt)
+      return {
+        accessToken: jwt,
+        lastAction: {
+          type: action.type,
+          payload: action.payload,
+        },
+        isAuthed: true,
+        isRequesting: false,
+        userInfo,
+      }
+    }
+    default: {
+      return state
+    }
+  }
+}

--- a/packages/universal-header/src/reducers/index.js
+++ b/packages/universal-header/src/reducers/index.js
@@ -1,0 +1,9 @@
+import { combineReducers } from 'redux'
+import authReducer from './auth'
+
+const rootReducer = combineReducers({
+  origins: (state = {}) => state,
+  auth: authReducer,
+})
+
+export default rootReducer

--- a/packages/universal-header/src/standalone-header.js
+++ b/packages/universal-header/src/standalone-header.js
@@ -1,13 +1,13 @@
-import { Provider } from 'react-redux'
 import Header from './containers/header'
 import PropTypes from 'prop-types'
 import React from 'react'
+import requestOrigins from '@twreporter/core/lib/constants/request-origins'
+import rootReducer from './reducers/index'
+import thunk from 'redux-thunk'
 import wellDefinedPropTypes from './constants/prop-types'
-// @twreporter
-import twreporterRedux from '@twreporter/redux'
-import origins from '@twreporter/core/lib/constants/request-origins'
-
-const isDev = process && process.env && process.env.NODE_ENV === 'development'
+import { Provider } from 'react-redux'
+import { applyMiddleware, createStore } from 'redux'
+import { getAccessToken } from './actions/auth'
 
 export default class StandaloneHeader extends React.PureComponent {
   static propTypes = {
@@ -27,19 +27,20 @@ export default class StandaloneHeader extends React.PureComponent {
   constructor(props) {
     super(props)
     const { releaseBranch } = this.props
-    const cookie = ''
-    this.store = twreporterRedux.createStore(
+    this.store = createStore(
+      rootReducer,
       {
-        [twreporterRedux.reduxStateFields.origins]:
-          origins.forClientSideRendering[releaseBranch],
+        origins: requestOrigins.forClientSideRendering[releaseBranch],
+        auth: {},
       },
-      cookie,
-      isDev
+      applyMiddleware(thunk)
     )
   }
 
   componentDidMount() {
-    this.store.actions.getAccessToken()
+    this.store.dispatch(getAccessToken()).catch(failAction => {
+      console.log(failAction)
+    })
   }
 
   render() {

--- a/packages/universal-header/src/utils/jwt.js
+++ b/packages/universal-header/src/utils/jwt.js
@@ -1,0 +1,25 @@
+import get from 'lodash/get'
+
+const _ = {
+  get,
+}
+
+/**
+ *  Decode the payload of JWT from base64 string into JSON object
+ *
+ *  @param {string} jwt
+ *  @return {Object} JSON object or null if decoding fails
+ */
+function decodePayload(jwt) {
+  try {
+    const payload = _.get(jwt.split('.'), 1)
+    return JSON.parse(Buffer.from(payload, 'base64').toString('utf8'))
+  } catch (err) {
+    console.error('extract payload from jwt error: ', err) // eslint-disable-line
+    return null
+  }
+}
+
+export default {
+  decodePayload,
+}


### PR DESCRIPTION
### Bug Description
The root cause is that the latest `@twreporter/redux/lib/store/createStore` return a `Promise` rather than a redux store instance.

### Solution
Decouple `@twreporter/redux`. 
Maintain redux store/actions/reducers by `@twreporter/universal-header` itself.