### PR TITLE
fix(footer): body's background shows when exceeds max-height

### DIFF
--- a/packages/react-components/src/footer/index.js
+++ b/packages/react-components/src/footer/index.js
@@ -20,9 +20,6 @@ const FooterContainer = styled.div`
   ${mq.tabletAndAbove`
     min-height: ${styles.footerHeight.desktop}px;
   `}
-  ${mq.mobileOnly`
-    max-height: 811px;
-  `}
   * {
     box-sizing: border-box;
   }


### PR DESCRIPTION
This patch removes `max-height` on mobile since it shows body's
background instead of white(footer's background color) when the
max-height is exceeded