### PR TITLE
feature: added text and via to Twitter share link

### DIFF
--- a/packages/react-article-components/src/components/aside/tools.js
+++ b/packages/react-article-components/src/components/aside/tools.js
@@ -202,7 +202,7 @@ function TwitterShareBT(props) {
     const currentURL = window.location.href
     const location =
       'https://twitter.com/intent/tweet?' +
-      `url=${encodeURIComponent(currentURL)}&text=${encodeURIComponent(document.title)}&via=tw_reporter_org`
+      `url=${encodeURIComponent(currentURL)}&text=${encodeURIComponent(document.title + ' #報導者')}`
 
     window.open(location, '_blank')
   }

--- a/packages/react-article-components/src/components/aside/tools.js
+++ b/packages/react-article-components/src/components/aside/tools.js
@@ -202,7 +202,7 @@ function TwitterShareBT(props) {
     const currentURL = window.location.href
     const location =
       'https://twitter.com/intent/tweet?' +
-      `url=${encodeURIComponent(currentURL)}`
+      `url=${encodeURIComponent(currentURL)}&text=${encodeURIComponent(document.title)}&via=tw_reporter_org`
 
     window.open(location, '_blank')
   }


### PR DESCRIPTION
First of all, huge thanks for this great website you built. 

As a Twitter user and a reader of The Reporter, it could be convenient for readers to share an article by just clicking the Twitter share icon and not doing anything else.

But surprisingly, I found the website only provides only the link to Twitter Web Intent API, so readers have to add the title manually, which is not convenient for readers who would like to share the article like me.

I luckily found the source code and decided to contribute. I hope this won't interrupt your work.

Thank you.