### PR TITLE
feat(react-article-components): update Relateds props

### DIFF
--- a/packages/react-article-components/dev/entry.js
+++ b/packages/react-article-components/dev/entry.js
@@ -3,7 +3,6 @@ import { Provider } from 'react-redux'
 import Article from '../src/components/article-page'
 import Header from '@twreporter/universal-header/lib/containers/header'
 import mockPost from './mock-post.json'
-import PropTypes from 'prop-types'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import styled from 'styled-components'
@@ -15,15 +14,12 @@ const HeaderContainerWithTransparentTheme = styled.div`
   position: relative;
 `
 
-class MockTwreporterReactArticleContainer extends React.PureComponent {
-  static propTypes = {
-    post: PropTypes.object,
-    relatedPosts: PropTypes.array,
-    relatedTopic: PropTypes.object,
-  }
+const defaultNumberOfRelateds = 6
 
+class MockTwreporterReactArticleContainer extends React.PureComponent {
   state = {
     fontLevel: 'small',
+    numberOfRelatedsToShow: defaultNumberOfRelateds,
   }
 
   handleFontLevelChange = nextFontLevel => {
@@ -32,14 +28,22 @@ class MockTwreporterReactArticleContainer extends React.PureComponent {
     })
   }
 
+  loadMoreRelateds = () => {
+    this.setState({
+      numberOfRelatedsToShow:
+        this.state.numberOfRelatedsToShow + defaultNumberOfRelateds,
+    })
+  }
+
   render() {
-    const { post, relatedPosts, relatedTopic } = this.props
-    const { fontLevel } = this.state
+    const { fontLevel, numberOfRelatedsToShow } = this.state
     return (
       <Article
-        post={post}
-        relatedPosts={relatedPosts}
-        relatedTopic={relatedTopic}
+        post={mockPost}
+        relatedPosts={mockPost.relateds.slice(0, numberOfRelatedsToShow)}
+        relatedTopic={mockPost.topics}
+        hasMoreRelateds={mockPost.relateds.length > numberOfRelatedsToShow}
+        loadMoreRelateds={this.loadMoreRelateds}
         fontLevel={fontLevel}
         onFontLevelChange={this.handleFontLevelChange}
       />
@@ -77,11 +81,7 @@ twreporterRedux.createStore({}, '', true).then(store => {
             releaseBranch="master"
           />
         </HeaderContainerWithTransparentTheme>
-        <MockTwreporterReactArticleContainer
-          post={mockPost}
-          relatedPosts={mockPost.relateds}
-          relatedTopic={mockPost.topics}
-        />
+        <MockTwreporterReactArticleContainer />
         <Footer />
       </Provider>
     </React.Fragment>,

--- a/packages/react-article-components/dev/mock-post.json
+++ b/packages/react-article-components/dev/mock-post.json
@@ -2828,7 +2828,7 @@
   "published_date": "2019-03-25T08:00:00+08:00",
   "updated_at": "2019-04-10T16:08:44.895+08:00",
   "full": true,
-  "topics": {
+  "topic": {
     "id": "5cd3b75044ebf71700c9606f",
     "slug": "2019-venice-biennale",
     "name": "2019-venice-biennale",

--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -277,6 +277,8 @@ const _fontLevel = {
  *  @property {string} topic_name - Name of topic
  */
 
+function noop() {}
+
 /**
  *  @exports
  */
@@ -292,6 +294,8 @@ export default class Article extends PureComponent {
     ]),
     LinkComponent: PropTypes.elementType,
     onFontLevelChange: PropTypes.func,
+    hasMoreRelateds: PropTypes.bool,
+    loadMoreRelateds: PropTypes.func,
   }
 
   static defaultProps = {
@@ -299,6 +303,8 @@ export default class Article extends PureComponent {
     fontLevel: _fontLevel.small,
     relatedPosts: [],
     relatedTopic: {},
+    hasMoreRelateds: false,
+    loadMoreRelateds: noop,
   }
 
   constructor(props) {
@@ -395,6 +401,8 @@ export default class Article extends PureComponent {
       post,
       relatedPosts,
       relatedTopic,
+      hasMoreRelateds,
+      loadMoreRelateds,
     } = this.props
 
     const articleMetaForBookmark = {
@@ -491,11 +499,13 @@ export default class Article extends PureComponent {
                 publishedDate={post.published_date}
               />
               <StyledSeparationCurve />
-              {_.get(relatedPosts, 'length', 0) > 0 ? (
-                <RelatedBlock>
-                  <Related data={relatedPosts} />
-                </RelatedBlock>
-              ) : null}
+              <RelatedBlock>
+                <Related
+                  data={relatedPosts}
+                  hasMore={hasMoreRelateds}
+                  loadMore={loadMoreRelateds}
+                />
+              </RelatedBlock>
             </BodyBackground>
           </BackgroundBlock>
         </DynamicComponentsContext.Provider>

--- a/packages/react-article-components/src/components/related/index.js
+++ b/packages/react-article-components/src/components/related/index.js
@@ -131,10 +131,13 @@ const screen = {
 export default class Related extends React.PureComponent {
   static propTypes = {
     data: PropTypes.array,
+    hasMore: PropTypes.bool,
+    loadMore: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
     data: [],
+    hasMore: false,
   }
 
   constructor(props) {
@@ -211,13 +214,18 @@ export default class Related extends React.PureComponent {
   }
 
   render() {
-    const { data } = this.props
+    const { data, hasMore, loadMore } = this.props
     const { lastWindowWidth } = this.state
     const relateds = _.map(data, this._buildRelated)
     return (
       <Block>
         <Descriptor />
-        <List key={`list-width-${lastWindowWidth}`} data={relateds} />
+        <List
+          key={`list-width-${lastWindowWidth}`}
+          data={relateds}
+          hasMore={hasMore}
+          loadMore={loadMore}
+        />
       </Block>
     )
   }


### PR DESCRIPTION
Let consumers to pass `loadMoreRelateds` to load more related posts,
and `hasMoreRelateds` to decide if to show load more button.

- article-page:
  - props added: hasMoreRelateds
  - props added: loadMoreRelateds

- related:
  - props added: hasMore
  - props added: loadMore

- dev/entry:
  - simulate load more related posts