### PR TITLE
fix(redux): filter selected post itself from its related posts

### DIFF
--- a/packages/redux/src/reducers/related-posts-of.js
+++ b/packages/redux/src/reducers/related-posts-of.js
@@ -86,7 +86,7 @@ export default function relatedPostsOf(state = initialState, action = {}) {
       }
 
       // deduplicate related posts according to their ids
-      more = _.uniq(more)
+      more = _.uniq(more).filter(relatedId => relatedId !== entityId)
 
       const allIds = _.get(state, 'allIds', [])
       const ids = []


### PR DESCRIPTION
### Reason to Change

After [PR: fix(redux): deduplicate related posts](https://github.com/twreporter/twreporter-npm-packages/pull/157) merged,
the duplicate related posts are removed.

However, in some situations, it will lack of one post like following example.
<img width="1115" alt="Screen Shot 2020-11-13 at 11 36 46 AM" src="https://user-images.githubusercontent.com/3000343/99025868-ce3e8480-25a4-11eb-92fb-a4ae960f11e8.png">

The reason is because that missing post is selected post itself. 
Hence it will be omitted while rendering.

This PR is to filter selected post itself from its related posts array.