### PR TITLE
refactor(react-article-components): add id tag to the aside tool

### DIFF
--- a/packages/react-article-components/src/components/aside/tools.js
+++ b/packages/react-article-components/src/components/aside/tools.js
@@ -187,7 +187,7 @@ function FBShareBT(props) {
   }
 
   return (
-    <ShareIconBlock>
+    <ShareIconBlock id="fb-share">
       <FBIcon width="30px" onClick={handleClick} />
     </ShareIconBlock>
   )
@@ -208,7 +208,7 @@ function TwitterShareBT(props) {
   }
 
   return (
-    <ShareIconBlock>
+    <ShareIconBlock id="twitter-share">
       <TwitterIcon width="30px" onClick={handleClick} />
     </ShareIconBlock>
   )
@@ -225,7 +225,7 @@ function LineShareBT(props) {
   }
 
   return (
-    <ShareIconBlock>
+    <ShareIconBlock id="line-share">
       <LineIcon width="30px" onClick={handleClick} />
     </ShareIconBlock>
   )


### PR DESCRIPTION
This patch adds the id tags to the social share icons(fb/twitter/line)
so that non-dev colleagues can leverage the CSS selector on GTM to
selector the icons independently.