### PR TITLE
refactor(universal-header): modify desktop icon show/hide flow

### DIFF
--- a/packages/universal-header/src/components/header.js
+++ b/packages/universal-header/src/components/header.js
@@ -64,14 +64,16 @@ class Header extends React.PureComponent {
   static propTypes = {
     pathname: PropTypes.string,
     channels: Channels.propTypes.data,
+    services: PropTypes.array,
   }
   static defaultProps = {
     pathname: '',
     channels: Channels.defaultProps.data,
+    services: [],
   }
 
   render() {
-    const { pathname, channels } = this.props
+    const { pathname, channels, services } = this.props
 
     const channelJSX = <Channels currentPathname={pathname} data={channels} />
     return (
@@ -88,7 +90,7 @@ class Header extends React.PureComponent {
                   >
                     <Logo />
                   </Link>
-                  <Icons />
+                  <Icons services={services} />
                 </TopRowContent>
               </TopRow>
             )

--- a/packages/universal-header/src/components/icons.js
+++ b/packages/universal-header/src/components/icons.js
@@ -1,5 +1,6 @@
 import HeaderContext from '../contexts/header-context'
 import Link from './customized-link'
+import PropTypes from 'prop-types'
 import React from 'react'
 import SearchBox from './search-box'
 import fonts from '../constants/fonts'
@@ -10,6 +11,12 @@ import styled from 'styled-components'
 import themeUtils from '../utils/theme'
 // @twreporter
 import mq from '@twreporter/core/lib/utils/media-query'
+// lodash
+import map from 'lodash/map'
+
+const _ = {
+  map,
+}
 
 const styles = {
   iconContainerSize: 3, // em
@@ -97,6 +104,14 @@ const HideOnDesktop = styled(IconContainer)`
 `
 
 class Icons extends React.PureComponent {
+  static propTypes = {
+    services: PropTypes.array,
+  }
+
+  static defaultProps = {
+    services: [],
+  }
+
   constructor(props) {
     super(props)
     this.state = {
@@ -133,38 +148,52 @@ class Icons extends React.PureComponent {
     window.location = linkUtils.getLoginLink(releaseBranch).to + '?' + query
   }
 
-  render() {
+  _prepareIconJsx(service) {
     const { isSearchOpened } = this.state
-    const Member = (
-      <HeaderContext.Consumer>
-        {({ isAuthed, releaseBranch, theme }) => {
-          const LogInIcon = themeUtils.selectServiceIcons(theme).member
-          const LogOutIcon = themeUtils.selectServiceIcons(theme).logout
-
-          return (
-            <a
-              onClick={e => {
-                this._handleLogIconClick(e, isAuthed, releaseBranch)
-              }}
-            >
-              {isAuthed ? (
-                <React.Fragment>
-                  <LogOutIcon />
-                  <span>{serviceConst.serviceLabels.logout}</span>
-                </React.Fragment>
-              ) : (
+    const Login = (
+      <IconContainer isSearchOpened={isSearchOpened}>
+        <HeaderContext.Consumer>
+          {({ releaseBranch, theme }) => {
+            const LogInIcon = themeUtils.selectServiceIcons(theme).member
+            return (
+              <a
+                onClick={e => {
+                  this._handleLogIconClick(e, false, releaseBranch)
+                }}
+              >
                 <React.Fragment>
                   <LogInIcon />
                   <span>{serviceConst.serviceLabels.login}</span>
                 </React.Fragment>
-              )}
-            </a>
-          )
-        }}
-      </HeaderContext.Consumer>
+              </a>
+            )
+          }}
+        </HeaderContext.Consumer>
+      </IconContainer>
     )
-    return (
-      <IconsContainer>
+    const Logout = (
+      <IconContainer isSearchOpened={isSearchOpened}>
+        <HeaderContext.Consumer>
+          {({ releaseBranch, theme }) => {
+            const LogOutIcon = themeUtils.selectServiceIcons(theme).logout
+            return (
+              <a
+                onClick={e => {
+                  this._handleLogIconClick(e, true, releaseBranch)
+                }}
+              >
+                <React.Fragment>
+                  <LogOutIcon />
+                  <span>{serviceConst.serviceLabels.logout}</span>
+                </React.Fragment>
+              </a>
+            )
+          }}
+        </HeaderContext.Consumer>
+      </IconContainer>
+    )
+    const Search = (
+      <React.Fragment>
         <DisplayOnDesktop
           onClick={this._handleClickSearch}
           isSearchOpened={isSearchOpened}
@@ -198,24 +227,49 @@ class Icons extends React.PureComponent {
             }}
           </HeaderContext.Consumer>
         </HideOnDesktop>
-        <IconContainer isSearchOpened={isSearchOpened}>
-          <HeaderContext.Consumer>
-            {({ releaseBranch, isLinkExternal, theme }) => {
-              const BookmarkIcon = themeUtils.selectServiceIcons(theme).bookmark
-              const link = linkUtils.getBookmarksLink(
-                isLinkExternal,
-                releaseBranch
-              )
-              return (
-                <Link {...link}>
-                  <BookmarkIcon />
-                  <span>{serviceConst.serviceLabels.bookmarks}</span>
-                </Link>
-              )
-            }}
-          </HeaderContext.Consumer>
-        </IconContainer>
-        <IconContainer isSearchOpened={isSearchOpened}>{Member}</IconContainer>
+      </React.Fragment>
+    )
+    const Bookmark = (
+      <IconContainer isSearchOpened={isSearchOpened}>
+        <HeaderContext.Consumer>
+          {({ releaseBranch, isLinkExternal, theme }) => {
+            const BookmarkIcon = themeUtils.selectServiceIcons(theme).bookmark
+            const link = linkUtils.getBookmarksLink(
+              isLinkExternal,
+              releaseBranch
+            )
+            return (
+              <Link {...link}>
+                <BookmarkIcon />
+                <span>{serviceConst.serviceLabels.bookmarks}</span>
+              </Link>
+            )
+          }}
+        </HeaderContext.Consumer>
+      </IconContainer>
+
+    )
+    switch(service) {
+      case 'login':
+        return Login
+      case 'logout':
+        return Logout
+      case 'search':
+        return Search
+      case 'bookmarks':
+        return Bookmark
+      case 'newsletter':
+      case 'support':
+      default:
+        return null;
+    }
+  }
+
+  render() {
+    const { services } = this.props;
+    return (
+      <IconsContainer>
+        { _.map(services, service => this._prepareIconJsx(service.key)) }
       </IconsContainer>
     )
   }

--- a/packages/universal-header/src/constants/services.js
+++ b/packages/universal-header/src/constants/services.js
@@ -23,12 +23,19 @@ export const servicePathnames = {
   [serviceKeys.search]: '/search',
 }
 
-export const serviceOrder = [
-  serviceKeys.search,
-  serviceKeys.bookmarks,
-  serviceKeys.support,
-  serviceKeys.newsLetter,
-]
+export const serviceOrder = {
+  mobile: [
+    serviceKeys.search,
+    serviceKeys.bookmarks,
+    serviceKeys.support,
+    serviceKeys.newsLetter,
+  ],
+  desktop: [
+    serviceKeys.support,
+    serviceKeys.newsLetter,
+    serviceKeys.search,
+  ],
+}
 
 export default {
   serviceKeys,

--- a/packages/universal-header/src/constants/services.js
+++ b/packages/universal-header/src/constants/services.js
@@ -34,6 +34,7 @@ export const serviceOrder = {
     serviceKeys.support,
     serviceKeys.newsLetter,
     serviceKeys.search,
+    serviceKeys.bookmarks,
   ],
 }
 

--- a/packages/universal-header/src/containers/header.js
+++ b/packages/universal-header/src/containers/header.js
@@ -111,7 +111,6 @@ class Container extends React.PureComponent {
     })
 
     if (isAuthed) {
-      const bookmarkKey = serviceConst.serviceKeys.bookmarks
       const logoutKey = serviceConst.serviceKeys.logout
       desktopServiceProps.push({ key: logoutKey })
       mobileServiceProps.unshift({

--- a/packages/universal-header/src/containers/header.js
+++ b/packages/universal-header/src/containers/header.js
@@ -98,7 +98,8 @@ class Container extends React.PureComponent {
       releaseBranch
     )
 
-    const serviceProps = serviceConst.serviceOrder.map(key => {
+    const desktopServiceProps = serviceConst.serviceOrder.desktop.map(key => ({ key }));
+    const mobileServiceProps = serviceConst.serviceOrder.mobile.map(key => {
       return {
         key,
         label: serviceConst.serviceLabels[key],
@@ -108,8 +109,11 @@ class Container extends React.PureComponent {
     })
 
     if (isAuthed) {
+      const bookmarkKey = serviceConst.serviceKeys.bookmarks
       const logoutKey = serviceConst.serviceKeys.logout
-      serviceProps.unshift({
+      desktopServiceProps.push({ key: bookmarkKey })
+      desktopServiceProps.push({ key: logoutKey })
+      mobileServiceProps.unshift({
         key: logoutKey,
         label: serviceConst.serviceLabels[logoutKey],
         link: serviceLinks[logoutKey],
@@ -117,7 +121,8 @@ class Container extends React.PureComponent {
       })
     } else {
       const loginKey = serviceConst.serviceKeys.login
-      serviceProps.unshift({
+      desktopServiceProps.push({ key: loginKey })
+      mobileServiceProps.unshift({
         key: loginKey,
         label: serviceConst.serviceLabels[loginKey],
         link: serviceLinks[loginKey],
@@ -125,7 +130,7 @@ class Container extends React.PureComponent {
       })
     }
 
-    return serviceProps
+    return { desktop: desktopServiceProps, mobile: mobileServiceProps }
   }
 
   __prepareChannelProps(releaseBranch, isLinkExternal) {
@@ -179,7 +184,7 @@ class Container extends React.PureComponent {
       releaseBranch,
       isLinkExternal
     )
-    const mobileMenu = mergeTwoArraysInOrder(channelProps, serviceProps)
+    const mobileMenu = mergeTwoArraysInOrder(channelProps, serviceProps.mobile)
 
     this.__prepareCategoriesProps(releaseBranch, isLinkExternal, channelProps)
 
@@ -189,7 +194,7 @@ class Container extends React.PureComponent {
           <MobileHeader menu={mobileMenu} {...passThrough} />
         </MobileOnly>
         <NonMobileOnly>
-          <Header channels={channelProps} {...passThrough} />
+          <Header channels={channelProps} services={serviceProps.desktop} {...passThrough} />
         </NonMobileOnly>
       </HeaderContext.Provider>
     )

--- a/packages/universal-header/src/containers/header.js
+++ b/packages/universal-header/src/containers/header.js
@@ -20,9 +20,11 @@ import { connect } from 'react-redux'
 import mq from '@twreporter/core/lib/utils/media-query'
 // lodash
 import get from 'lodash/get'
+import map from 'lodash/map'
 
 const _ = {
   get,
+  map,
 }
 
 const MobileOnly = styled.div`
@@ -98,8 +100,8 @@ class Container extends React.PureComponent {
       releaseBranch
     )
 
-    const desktopServiceProps = serviceConst.serviceOrder.desktop.map(key => ({ key }));
-    const mobileServiceProps = serviceConst.serviceOrder.mobile.map(key => {
+    const desktopServiceProps = _.map(serviceConst.serviceOrder.desktop, key => ({ key }));
+    const mobileServiceProps = _.map(serviceConst.serviceOrder.mobile, (key) => {
       return {
         key,
         label: serviceConst.serviceLabels[key],
@@ -109,9 +111,7 @@ class Container extends React.PureComponent {
     })
 
     if (isAuthed) {
-      const bookmarkKey = serviceConst.serviceKeys.bookmarks
       const logoutKey = serviceConst.serviceKeys.logout
-      desktopServiceProps.push({ key: bookmarkKey })
       desktopServiceProps.push({ key: logoutKey })
       mobileServiceProps.unshift({
         key: logoutKey,
@@ -134,7 +134,7 @@ class Container extends React.PureComponent {
   }
 
   __prepareChannelProps(releaseBranch, isLinkExternal) {
-    const channelProps = channelConst.channelOrder.map(key => {
+    const channelProps = _.map(channelConst.channelOrder, (key) => {
       return {
         key,
         label: channelConst.channelLabels[key],
@@ -150,7 +150,7 @@ class Container extends React.PureComponent {
   __prepareCategoriesProps(releaseBranch, isLinkExternal, channelProps) {
     channelProps[
       channelProps.length - 1
-    ].dropDownMenu = categoryConst.categoryOrder.map(key => {
+    ].dropDownMenu = _.map(categoryConst.categoryOrder, (key) => {
       return {
         key,
         label: categoryConst.categoryLabels[key],

--- a/packages/universal-header/src/containers/header.js
+++ b/packages/universal-header/src/containers/header.js
@@ -111,6 +111,7 @@ class Container extends React.PureComponent {
     })
 
     if (isAuthed) {
+      const bookmarkKey = serviceConst.serviceKeys.bookmarks
       const logoutKey = serviceConst.serviceKeys.logout
       desktopServiceProps.push({ key: logoutKey })
       mobileServiceProps.unshift({


### PR DESCRIPTION
[Summary]
bookmark icon only show when login & modify desktop icon show/hide flow

[Related story]
twreporter-73

[Scope]
universal-header

[Change]
Before change, Icons component will always render bookmark icon & determine to render login/logout inside itself.
After change, header container component will determine which icons to render, then pass it to Icons component. 