### PR TITLE
refactor(errors): remain the first line of stack trace

### DIFF
--- a/packages/errors/src/helpers/print.js
+++ b/packages/errors/src/helpers/print.js
@@ -3,8 +3,12 @@ import helpers from './general'
 function trimLinesFromTheBottom(string, trimmedCount) {
   if (!trimmedCount || !string) return string
   const array = string.split(/\r?\n|\r/)
-  array.splice(array.length - trimmedCount, trimmedCount)
-  return array.join('\n')
+  if (array.length > trimmedCount) {
+    array.splice(array.length - trimmedCount, trimmedCount);
+  } else {
+    array.splice(1, array.length - 1);
+  }
+  return array.join('\n');
 }
 
 /**


### PR DESCRIPTION
### Change Reason
If the stack lines of error are less than trimmedCount, the whole stack lines will be deleted.
This patch remains the first line of error stack.