### PR TITLE
refactor: update topic label style for article page

### DIFF
--- a/packages/react-article-components/src/components/leading/normal.js
+++ b/packages/react-article-components/src/components/leading/normal.js
@@ -103,7 +103,7 @@ const FigCaption = styled.figcaption`
 
 const BackgroundBlock = styled.div`
   ${props => getBackgroundBlockStyles(props.theme.name)}
-  padding-top: 10px;
+  padding-top: 30px;
   ${mq.tabletOnly`
     padding-top: 30px;
   `}


### PR DESCRIPTION
Address [TWREPORTER-158](https://twreporter-org.atlassian.net/browse/TWREPORTER-158).

This patch updates topic label style for article page to increase margin
between header and topic label for normal article page.