### PR TITLE
fix: article table of content should be top of everything

### DIFF
--- a/packages/react-article-components/src/constants/position-z-index.js
+++ b/packages/react-article-components/src/constants/position-z-index.js
@@ -1,4 +1,7 @@
 export default {
   // table-of-contents
-  toc: 10,
+  // z-index is set for covering web-push & header.
+  // Set z-index to 1002 because web-push has z-index 1001,
+  // And header has z-index 1000.
+  toc: 1002,
 }


### PR DESCRIPTION
- current z-index: toc > web push > universal header