### PR TITLE
fix: disappear mobile aside/index in print mode

### DIFF
--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -85,6 +85,13 @@ const BodyBackground = styled.div`
 const BodyBlock = styled.div`
   position: relative;
   width: 100%;
+
+  @media print {
+    .hidden-print {
+      display: none;
+    }
+  }
+
   ${mq.desktopOnly`
     max-width: 1024px;
     margin: 0 auto;

--- a/packages/react-article-components/src/components/aside/mobile-aside.js
+++ b/packages/react-article-components/src/components/aside/mobile-aside.js
@@ -84,7 +84,7 @@ class MobileAside extends React.PureComponent {
 
     const { toShow } = this.state
     return (
-      <Container toShow={toShow}>
+      <Container className="hidden-print" toShow={toShow}>
         {backToTopic ? <BackToTopicBtn href={backToTopic} /> : null}
         <BookmarkWidget
           toAutoCheck

--- a/packages/react-article-components/src/components/table-of-contents/index.js
+++ b/packages/react-article-components/src/components/table-of-contents/index.js
@@ -77,7 +77,7 @@ class TableOfContents extends React.PureComponent {
     const { isExpanded } = this.state
 
     return (
-      <div ref={this._ref}>
+      <div className="hidden-print" ref={this._ref}>
         <TOC.React.TableOfContents
           className={className}
           manager={manager}


### PR DESCRIPTION
**combine jira ticket [219](https://twreporter-org.atlassian.net/jira/software/c/projects/TWREPORTER/boards/7?modal=detail&selectedIssue=TWREPORTER-219), [220](https://twreporter-org.atlassian.net/jira/software/c/projects/TWREPORTER/boards/7?modal=detail&selectedIssue=TWREPORTER-220) to remove duplicate css**

1. 219: 套用media print使文章左側的索引在print mode不會顯示
  * dev可測的文章: http://localhost:3000/a/child-health-care-save-their-lives

2. 220:
![截圖 2022-03-02 下午3 24 20](https://user-images.githubusercontent.com/25971696/156508836-2ec5f3ee-d770-4ab9-b760-45b5fad135da.png)
  * mq似乎不能在print mode中辨認device, 所以在列印時還是會render右下的mobile aside, 而且要reproduce bug要header的評論/專題/攝影…這個list有縮放(scroll down)再按列印(cmd + p)
