### PR TITLE
Jason/figure div avoid break

### DIFF
--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -86,16 +86,6 @@ const BodyBlock = styled.div`
   position: relative;
   width: 100%;
 
-  @media print {
-    .hidden-print {
-      display: none;
-    }
-
-    .avoid-break {
-      break-inside: avoid;
-    }
-  }
-
   ${mq.desktopOnly`
     max-width: 1024px;
     margin: 0 auto;
@@ -198,10 +188,17 @@ const RelatedBlock = styled.div`
 
 const BackgroundBlock = styled(BorderBox)`
   ${fontFamilyCss}
-  ${props =>
-    getBackgroundBlockStyles(
-      props.theme.name
-    )}
+  ${props => getBackgroundBlockStyles(props.theme.name)}
+
+  @media print {
+    .hidden-print {
+      display: none;
+    }
+
+    .avoid-break {
+      break-inside: avoid;
+    }
+  }
 
   /* boreder-(right|left) of articlePage */
   padding-left: 10px;

--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -90,6 +90,10 @@ const BodyBlock = styled.div`
     .hidden-print {
       display: none;
     }
+
+    .avoid-break {
+      break-inside: avoid;
+    }
   }
 
   ${mq.desktopOnly`

--- a/packages/react-article-components/src/components/aside/mobile-aside.js
+++ b/packages/react-article-components/src/components/aside/mobile-aside.js
@@ -11,8 +11,6 @@ import BackToTopicIcon from '../../assets/aside/back-to-topic-mobile.svg'
 import ToAddBookmarkIcon from '../../assets/aside/add-bookmark-mobile.svg'
 import AddedBookmarkIcon from '../../assets/aside/added-bookmark-mobile.svg'
 
-import featureFlags from '../../constants/feature-flags'
-
 const Container = styled.div`
   ${mq.tabletAndBelow`
     display: inline-block;
@@ -86,10 +84,7 @@ class MobileAside extends React.PureComponent {
 
     const { toShow } = this.state
     return (
-      <Container
-        className={featureFlags.disableHiddenPrint ? '' : 'hidden-print'}
-        toShow={toShow}
-      >
+      <Container className="hidden-print" toShow={toShow}>
         {backToTopic ? <BackToTopicBtn href={backToTopic} /> : null}
         <BookmarkWidget
           toAutoCheck

--- a/packages/react-article-components/src/components/body/slideshow/index.js
+++ b/packages/react-article-components/src/components/body/slideshow/index.js
@@ -697,9 +697,10 @@ export default class Slideshow extends PureComponent {
 
     const slides = this.buildSlides(images)
     const desc = _.get(images, [curSlideIndex, 'description'])
+    const appendedClassName = className + ' avoid-break'
 
     return (
-      <SlideshowFlexBox className={className}>
+      <SlideshowFlexBox className={appendedClassName}>
         <SlidesSection>
           <SlidesFlexBox
             translateXUint={translateXUint}

--- a/packages/react-article-components/src/components/img-with-placeholder/index.js
+++ b/packages/react-article-components/src/components/img-with-placeholder/index.js
@@ -224,11 +224,15 @@ export default class Img extends React.PureComponent {
       sizes,
     } = this.props
 
+    const appendedClassName = className + ' avoid-break'
     const defaultImageOriginalUrl = _.get(defaultImage, 'url')
     /* Render placeholder only if no valid image is given */
     if (!defaultImageOriginalUrl && (!imageSet || imageSet.length === 0)) {
       return (
-        <ImgContainer className={className} heightString="height: 100%;">
+        <ImgContainer
+          className={appendedClassName}
+          heightString="height: 100%;"
+        >
           {this._renderImagePlaceholder()}
         </ImgContainer>
       )
@@ -250,7 +254,7 @@ export default class Img extends React.PureComponent {
 
     return (
       <ImgContainer
-        className={className}
+        className={appendedClassName}
         heightString={
           isObjectFit
             ? `height: 100%;`

--- a/packages/react-article-components/src/components/table-of-contents/index.js
+++ b/packages/react-article-components/src/components/table-of-contents/index.js
@@ -5,8 +5,6 @@ import TOC from '@twreporter/react-components/lib/table-of-contents'
 import map from 'lodash/map'
 import Tab from '../../assets/table-of-contents/long-form-tab.svg'
 
-import featureFlags from '../../constants/feature-flags'
-
 const _ = {
   map,
 }
@@ -79,10 +77,7 @@ class TableOfContents extends React.PureComponent {
     const { isExpanded } = this.state
 
     return (
-      <div
-        className={featureFlags.disableHiddenPrint ? '' : 'hidden-print'}
-        ref={this._ref}
-      >
+      <div className="hidden-print" ref={this._ref}>
         <TOC.React.TableOfContents
           className={className}
           manager={manager}

--- a/packages/react-article-components/src/constants/feature-flags.js
+++ b/packages/react-article-components/src/constants/feature-flags.js
@@ -1,6 +1,0 @@
-// TODO: delete this flag after hot fix of liveblog
-const disableHiddenPrint = true
-
-export default {
-  disableHiddenPrint,
-}


### PR DESCRIPTION
- fix [jira 221](https://twreporter-org.atlassian.net/jira/software/c/projects/TWREPORTER/boards/7?modal=detail&selectedIssue=TWREPORTER-221)
- test article: https://staging.twreporter.org/a/youth-house-rent-greater-taipei-no-choice
- 圖看起來破掉的原因：
ImgContainer在沒跨頁時顯示沒有問題，顯示的機制會參考長寬比，然後用padding-top + overflow的方式來控制圖片高度，一但跨頁parent div斷掉就會把padding顯示成空白，把圖擠下去
- workaround: img parent的div設break-inside: avoid; 
- ref: https://stackoverflow.com/questions/907680/css-printing-avoiding-cut-in-half-divs-between-pages
- ~~PS: 因為dev環境沒有圖，這個PR需要merge到staging比較好測試~~

![截圖 2022-03-11 下午1 56 52](https://user-images.githubusercontent.com/25971696/157811131-001c2a24-5996-4bb9-8ae9-8908b4ec26f6.png)