### PR TITLE
fix: update line-break property to avoid unexpected line break

### DIFF
--- a/packages/index-page/src/components/editor-picks.js
+++ b/packages/index-page/src/components/editor-picks.js
@@ -172,6 +172,7 @@ const Title = styled.div`
   left: 50%;
   transform: translateX(-50%);
   overflow: hidden;
+  line-break: anywhere;
   ${finalMedia.desktop`
     width: ${props => (props.middle ? '450px' : '120px')};
   `}


### PR DESCRIPTION
This patch set `line-break: anywhere;` in title of editor picks to avoid
unexpected line break caused by punctuation characters.