### PR TITLE
Jason/image diff print issue

### DIFF
--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -191,6 +191,10 @@ const BackgroundBlock = styled(BorderBox)`
   ${props => getBackgroundBlockStyles(props.theme.name)}
 
   @media print {
+    // Fix background-image printing issue
+    -webkit-print-color-adjust: exact; // Chrome/Safari/Edge
+    color-adjust: exact; // Firefox
+
     .hidden-print {
       display: none;
     }

--- a/packages/react-article-components/src/components/body/image-diff.js
+++ b/packages/react-article-components/src/components/body/image-diff.js
@@ -150,7 +150,7 @@ export default class ImageDiff extends PureComponent {
     return (
       <Container>
         <ImageContainer
-          className={'avoid-break'}
+          className="avoid-break"
           heightWidthRatio={renderedHeightWidthRation}
           leftImageSet={leftImageSet}
           rightImageSet={rightImageSet}

--- a/packages/react-article-components/src/components/body/image-diff.js
+++ b/packages/react-article-components/src/components/body/image-diff.js
@@ -31,6 +31,10 @@ const getResponsiveBackground = imageSetPropKey => css`
     background-image: url(${props =>
       replaceGCSUrlOrigin(_.get(props, [imageSetPropKey, 'mobile', 'url']))});
   `}
+  @media print {
+    background-image: url(${props =>
+      replaceGCSUrlOrigin(_.get(props, [imageSetPropKey, 'desktop', 'url']))});
+  }
 `
 
 const sharedStyleOfIndicatorPointer = css`
@@ -146,6 +150,7 @@ export default class ImageDiff extends PureComponent {
     return (
       <Container>
         <Image
+          className={'avoid-break'}
           heightWidthRatio={renderedHeightWidthRation}
           leftImageSet={leftImageSet}
           rightImageSet={rightImageSet}

--- a/packages/react-article-components/src/components/body/image-diff.js
+++ b/packages/react-article-components/src/components/body/image-diff.js
@@ -60,7 +60,7 @@ const sharedStyleOfIndicatorPointer = css`
   }};
 `
 
-const Image = styled.div`
+const ImageContainer = styled.div`
   overflow: hidden;
   position: relative;
   width: 100%;
@@ -149,7 +149,7 @@ export default class ImageDiff extends PureComponent {
     )
     return (
       <Container>
-        <Image
+        <ImageContainer
           className={'avoid-break'}
           heightWidthRatio={renderedHeightWidthRation}
           leftImageSet={leftImageSet}
@@ -158,7 +158,7 @@ export default class ImageDiff extends PureComponent {
           <div>
             <Slider defaultValue={50} min={1} max={100} />
           </div>
-        </Image>
+        </ImageContainer>
         {caption ? <Multimedia.Caption>{caption}</Multimedia.Caption> : null}
       </Container>
     )

--- a/packages/react-article-components/src/components/body/image.js
+++ b/packages/react-article-components/src/components/body/image.js
@@ -33,8 +33,9 @@ export default class Image extends PureComponent {
     const image = _.get(data, ['content', 0])
     const caption = _.get(image, 'description')
     const alt = _.get(image, 'keywords', caption)
+    const appendedClassName = className + ' avoid-break'
     return (
-      <Container className={className} small={small}>
+      <Container className={appendedClassName} small={small}>
         <figure itemScope itemType="http://schema.org/ImageObject">
           <Img
             alt={alt}


### PR DESCRIPTION
- fixed [#262](https://twreporter-org.atlassian.net/browse/TWREPORTER-262)
- issue:
  - 1. background-image在print mode不會顯示, css solution: https://stackoverflow.com/questions/6670151/how-can-i-force-browsers-to-print-background-images-in-css
  - 2. chrome在**第一次**load頁面, print mode下image diff的background-image顯示不出來(可能是chrome的bug, 其他browser不會), 但在getResponsiveBackground明確指定後可解決，猜測跟mq有關

![截圖 2022-03-23 下午4 20 40](https://user-images.githubusercontent.com/25971696/159654974-9815491d-949b-4ea4-9d36-89fb88227ffa.png)
![截圖 2022-03-23 下午4 20 53](https://user-images.githubusercontent.com/25971696/159655007-ed1e8e1c-a9f7-4aab-a740-310ff51f6ebc.png)
