### PR TITLE
refactor: update howler config for large audio files

### DIFF
--- a/packages/react-article-components/package.json
+++ b/packages/react-article-components/package.json
@@ -28,7 +28,7 @@
     "@twreporter/react-components": "^8.8.0-rc.0",
     "@twreporter/redux": "^7.2.1",
     "@twreporter/universal-header": "^2.2.8-rc.0",
-    "howler": "^2.1.1",
+    "howler": "^2.2.3",
     "lodash": "^4.17.11",
     "memoize-one": "^5.0.5",
     "prop-types": "^15.0.0",

--- a/packages/react-article-components/src/components/body/audio/audio-provider.js
+++ b/packages/react-article-components/src/components/body/audio/audio-provider.js
@@ -115,6 +115,8 @@ export default class AudioProvider extends PureComponent {
       src: this.props.src,
       autoplay: false,
       loop: false,
+      html5: true,
+      preload: 'metadata',
       onload: () => {
         this.setState({
           duration: this._sound.duration(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9738,10 +9738,10 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
   integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
-howler@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/howler/-/howler-2.1.2.tgz#8433a09d8fe84132a3e726e05cb2bd352ef8bd49"
-  integrity sha512-oKrTFaVXsDRoB/jik7cEpWKTj7VieoiuzMYJ7E/EU5ayvmpRhumCv3YQ3823zi9VTJkSWAhbryHnlZAionGAJg==
+howler@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.3.tgz#a2eff9b08b586798e7a2ee17a602a90df28715da"
+  integrity sha512-QM0FFkw0LRX1PR8pNzJVAY25JhIWvbKMBFM4gqk+QdV+kPXOhleWGCB6AiAF/goGjIHK2e/nIElplvjQwhr0jg==
 
 hpack.js@^2.1.6:
   version "2.1.6"


### PR DESCRIPTION
Address [TWREPORTER-317](https://twreporter-org.atlassian.net/browse/TWREPORTER-317)

This patch updates howler config for large audio files so that users
don't have to wait for the full file to be downloaded and decoded
before playing.

Also, set 'preload' to 'metadata' to preload the file's metadata
to get its duration without download the entire file.

ref: 
- html5: https://github.com/goldfire/howler.js#html5-boolean-false
- preload: https://github.com/goldfire/howler.js#preload-booleanstring-true