### PR TITLE
feat: add bookmark list empty guide

### DIFF
--- a/packages/react-components/src/bookmark-list/bookmarks.js
+++ b/packages/react-components/src/bookmark-list/bookmarks.js
@@ -1,10 +1,16 @@
-import { fontWeight } from '@twreporter/core/lib/constants/font'
-import Bookmark from './bookmark'
-import corePropTypes from '@twreporter/core/lib/constants/prop-types'
-import mq from '@twreporter/core/lib/utils/media-query'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
+// components
+import Bookmark from './bookmark'
+import EmptyGuide from './empty-guide'
+import { H1 } from '../text/headline'
+import { P1 } from '../text/paragraph'
+import Divider from '../divider'
+// @twreporter
+import mq from '@twreporter/core/lib/utils/media-query'
+import corePropTypes from '@twreporter/core/lib/constants/prop-types'
+import releaseBranchConsts from '@twreporter/core/lib/constants/release-branch'
 // lodash
 import get from 'lodash/get'
 import map from 'lodash/map'
@@ -39,33 +45,31 @@ const Column = styled.div`
 const StatusBar = styled.div`
   ${mq.mobileOnly`
     padding-left: 1em;
+    padding-right: 1em;
   `}
-  padding-bottom: 25px;
-  width: 100%;
+  padding-bottom: 64px;
+  width: stretch;
 `
 
-const CountTitle = styled.span`
-  font-size: 20px;
-  ${mq.mobileOnly`
-    font-size: 18px;
-  `}
-  margin-right: 1em;
-`
-const CountNumber = styled.span`
-  font-size: 20px;
-  ${mq.mobileOnly`
-    font-size: 18px;
-  `}
-  font-weight: ${fontWeight.bold};
+const TitleContainer = styled.div`
+  margin-bottom: 16px;
 `
 
+const CountContainer = styled.div`
+  display: flex;
+  margin-bottom: 16px;
+`
+
+const CountTitle = styled.div`
+  margin-right: 8px;
+`
 const BookmarksContainer = styled.ul`
   margin: 0;
   width: 100%;
   padding: 0;
 `
 
-function Bookmarks({ total, bookmarks, handleDelete }) {
+function Bookmarks({ total, bookmarks, handleDelete, releaseBranch }) {
   const buildBookmark = bookmark => (
     <Bookmark
       key={`bookmark_${_.get(bookmark, 'id')}`}
@@ -73,16 +77,34 @@ function Bookmarks({ total, bookmarks, handleDelete }) {
       handleDelete={handleDelete}
     />
   )
+  const counterJSX =
+    total === 0 ? (
+      ''
+    ) : (
+      <CountContainer>
+        <CountTitle>
+          <P1 text="全部" weight="bold" />
+        </CountTitle>
+        <P1 text={total} weight="bold" />
+      </CountContainer>
+    )
+  const contentJSX =
+    total === 0 ? (
+      <EmptyGuide releaseBranch={releaseBranch} />
+    ) : (
+      <BookmarksContainer>{_.map(bookmarks, buildBookmark)}</BookmarksContainer>
+    )
   return (
     <PageContainer>
       <Column>
         <StatusBar>
-          <CountTitle>全部</CountTitle>
-          <CountNumber>{total}</CountNumber>
+          <TitleContainer>
+            <H1 text="我的書籤" />
+          </TitleContainer>
+          {counterJSX}
+          <Divider />
         </StatusBar>
-        <BookmarksContainer>
-          {_.map(bookmarks, buildBookmark)}
-        </BookmarksContainer>
+        {contentJSX}
       </Column>
     </PageContainer>
   )
@@ -91,12 +113,14 @@ function Bookmarks({ total, bookmarks, handleDelete }) {
 Bookmarks.defaultProps = {
   bookmarks: [],
   total: 0,
+  releaseBranch: releaseBranchConsts.master,
 }
 
 Bookmarks.propTypes = {
-  bookmarks: PropTypes.arrayOf(corePropTypes).isRequired,
+  bookmarks: PropTypes.arrayOf(corePropTypes.bookmark).isRequired,
   handleDelete: PropTypes.func.isRequired,
   total: PropTypes.number,
+  releaseBranch: corePropTypes.releaseBranch,
 }
 
 export default Bookmarks

--- a/packages/react-components/src/bookmark-list/empty-guide.js
+++ b/packages/react-components/src/bookmark-list/empty-guide.js
@@ -43,19 +43,16 @@ const GuideContainer = styled.div`
 const EmptyGuide = ({ releaseBranch = releaseBranchConsts.master }) => {
   const homepageUrl = requestOrigin.forClientSideRendering[releaseBranch].main
   const seekImageUrl = `https://www.twreporter.org/assets/bookmark/${releaseBranch}/seek.png`
-  const guideJSX = (
-    <GuideContainer>
-      <P2 text="點擊" />
-      <Bookmark type="add" releaseBranch={releaseBranch} />
-      <P2 text="將喜愛的文章加入我的書籤" />
-    </GuideContainer>
-  )
   return (
     <Container>
       <img alt="Seek Bookmark" src={seekImageUrl} width="170" />
       <TextContainer>
         <P1 text="你還沒有儲存任何文章！" weight="bold" />
-        {guideJSX}
+        <GuideContainer>
+          <P2 text="點擊" />
+          <Bookmark type="add" releaseBranch={releaseBranch} />
+          <P2 text="將喜愛的文章加入我的書籤" />
+        </GuideContainer>
       </TextContainer>
       <ButtonContainer href={homepageUrl}>
         <PillButton text="開始探索" size="L" releaseBranch={releaseBranch} />

--- a/packages/react-components/src/bookmark-list/empty-guide.js
+++ b/packages/react-components/src/bookmark-list/empty-guide.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import styled from 'styled-components'
+// @twreporter
+import { colorGrayscale } from '@twreporter/core/lib/constants/color'
+import predefinedPropTypes from '@twreporter/core/lib/constants/prop-types'
+import releaseBranchConsts from '@twreporter/core/lib/constants/release-branch'
+import requestOrigin from '@twreporter/core/lib/constants/request-origins'
+// components
+import { Bookmark } from '../icon'
+import { P1, P2 } from '../text/paragraph'
+import { PillButton } from '../button'
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 8px;
+`
+
+const TextContainer = styled.div`
+  margin: 48px 0 24px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const ButtonContainer = styled.a`
+  text-decoration: none;
+`
+
+const GuideContainer = styled.div`
+  display: flex;
+  color: ${colorGrayscale.gray600};
+  svg {
+    background-color: ${colorGrayscale.gray600};
+    width: 18px;
+    height: 18px;
+    margin: 0 4px;
+  }
+`
+
+const EmptyGuide = ({ releaseBranch = releaseBranchConsts.master }) => {
+  const homepageUrl = requestOrigin.forClientSideRendering[releaseBranch].main
+  const seekImageUrl = `https://www.twreporter.org/assets/bookmark/${releaseBranch}/seek.png`
+  const guideJSX = (
+    <GuideContainer>
+      <P2 text="點擊" />
+      <Bookmark type="add" releaseBranch={releaseBranch} />
+      <P2 text="將喜愛的文章加入我的書籤" />
+    </GuideContainer>
+  )
+  return (
+    <Container>
+      <img alt="Seek Bookmark" src={seekImageUrl} width="170" />
+      <TextContainer>
+        <P1 text="你還沒有儲存任何文章！" weight="bold" />
+        {guideJSX}
+      </TextContainer>
+      <ButtonContainer href={homepageUrl}>
+        <PillButton text="開始探索" size="L" releaseBranch={releaseBranch} />
+      </ButtonContainer>
+    </Container>
+  )
+}
+EmptyGuide.propTypes = {
+  releaseBranch: predefinedPropTypes.releaseBranch,
+}
+
+export default EmptyGuide

--- a/packages/react-components/src/bookmark-list/index.js
+++ b/packages/react-components/src/bookmark-list/index.js
@@ -1,16 +1,18 @@
 import { connect } from 'react-redux'
-import { getSignInHref } from '@twreporter/core/lib/utils/sign-in-href'
-import Bookmarks from './bookmarks'
-import Confirmation from '../confirmation'
-import corePropTypes from '@twreporter/core/lib/constants/prop-types'
 import CSSTransition from 'react-transition-group/CSSTransition'
-import More from '../more'
 import PropTypes from 'prop-types'
 import React from 'react'
-import RedirectToSignIn from './redirect-to-sign-in'
 import styled, { css } from 'styled-components'
+// components
+import Bookmarks from './bookmarks'
+import Confirmation from '../confirmation'
+import More from '../more'
+import RedirectToSignIn from './redirect-to-sign-in'
+// @twreporter
 import twreporterRedux from '@twreporter/redux'
-
+import { getSignInHref } from '@twreporter/core/lib/utils/sign-in-href'
+import corePropTypes from '@twreporter/core/lib/constants/prop-types'
+import releaseBranchConsts from '@twreporter/core/lib/constants/release-branch'
 // lodash
 import findIndex from 'lodash/findIndex'
 import get from 'lodash/get'
@@ -171,13 +173,14 @@ class BookmarkList extends React.Component {
     const { isAuthed, jwt } = this.props
     if (!isAuthed || !jwt)
       return <RedirectToSignIn>您尚未登入，將跳轉至登入頁</RedirectToSignIn>
-    const { bookmarks, total } = this.props
+    const { bookmarks, total, releaseBranch } = this.props
     return (
       <Container>
         <Bookmarks
           bookmarks={bookmarks}
           handleDelete={this.handleDeleteButtonClicked}
           total={total}
+          releaseBranch={releaseBranch}
         />
         <MoreContainer hasMore={bookmarks.length < total}>
           <More loadMore={this.loadMoreBookmarks}>
@@ -208,6 +211,7 @@ class BookmarkList extends React.Component {
 }
 
 BookmarkList.propTypes = {
+  releaseBranch: corePropTypes.releaseBranch,
   // Props below are provided by redux
   bookmarks: PropTypes.arrayOf(corePropTypes.bookmark).isRequired,
   total: PropTypes.number.isRequired,
@@ -216,6 +220,10 @@ BookmarkList.propTypes = {
   isAuthed: PropTypes.bool.isRequired,
   jwt: PropTypes.string.isRequired,
   userID: PropTypes.number.isRequired,
+}
+
+BookmarkList.defaultProps = {
+  releaseBranch: releaseBranchConsts.master,
 }
 
 const mapStateToProps = state => {

--- a/packages/react-components/src/bookmark-list/stories/bookmark.stories.js
+++ b/packages/react-components/src/bookmark-list/stories/bookmark.stories.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import Bookmarks from '../bookmarks'
+
+export default {
+  title: 'Bookmark/Empty List',
+  component: Bookmarks,
+}
+
+export const emptyList = () => <Bookmarks />
+emptyList.args = {
+  bookmarks: [],
+  total: 0,
+}

--- a/packages/react-components/src/bookmark-list/stories/empty-guide.stories.js
+++ b/packages/react-components/src/bookmark-list/stories/empty-guide.stories.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import EmptyGuide from '../empty-guide'
+import releaseBranch from '@twreporter/core/lib/constants/release-branch'
+const { master, staging, preview, release } = releaseBranch
+
+export default {
+  title: 'Bookmark/Empty Guide',
+  component: EmptyGuide,
+  argTypes: {
+    releaseBranch: {
+      defaultValue: master,
+      options: [master, staging, preview, release],
+      control: { type: 'radio' },
+    },
+  },
+}
+
+export const emptyGuide = args => <EmptyGuide {...args} />

--- a/packages/react-components/src/button/index.js
+++ b/packages/react-components/src/button/index.js
@@ -1,0 +1,7 @@
+import PillButton from './components/pillButton'
+
+export { PillButton }
+
+export default {
+  PillButton,
+}


### PR DESCRIPTION
This patch address [TWREPORTER-291](https://twreporter-org.atlassian.net/browse/TWREPORTER-291).
- add empty guide component & story

For testing, please test with `twreporter-react` [#2122](https://github.com/twreporter/twreporter-react/pull/2122).