### PR TITLE
fix: add pillButton iconComponent prop & fix empty bookmark style

### DIFF
--- a/packages/react-components/src/bookmark-list/empty-guide.js
+++ b/packages/react-components/src/bookmark-list/empty-guide.js
@@ -32,14 +32,14 @@ const ButtonContainer = styled.a`
 
 const GuideContainer = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
   color: ${colorGrayscale.gray600};
   svg {
     background-color: ${colorGrayscale.gray600};
-    width: 14px;
-    height: 14px;
+    width: 18px;
+    height: 18px;
     margin: 0 4px;
-    padding-bottom: 4px;
+    transform: translateY(3px);
   }
 `
 
@@ -58,7 +58,7 @@ const EmptyGuide = ({ releaseBranch = releaseBranchConsts.master }) => {
         </GuideContainer>
       </TextContainer>
       <ButtonContainer href={homepageUrl}>
-        <PillButton text="開始探索" size="L" releaseBranch={releaseBranch} />
+        <PillButton text="開始探索" size="L" />
       </ButtonContainer>
     </Container>
   )

--- a/packages/react-components/src/button/components/iconButton.js
+++ b/packages/react-components/src/button/components/iconButton.js
@@ -43,7 +43,7 @@ const IconButton = ({
   )
 }
 IconButton.propTypes = {
-  iconComponent: PropTypes.elementType.isRequired,
+  iconComponent: PropTypes.element.isRequired,
   theme: PropTypes.oneOf(['normal', 'photography', 'transparent', 'index']),
   type: PropTypes.oneOf(['primary', 'secondary']),
   disabled: PropTypes.bool,

--- a/packages/react-components/src/button/components/iconWithTextButton.js
+++ b/packages/react-components/src/button/components/iconWithTextButton.js
@@ -52,7 +52,7 @@ const IconWithTextButton = ({
 }
 IconWithTextButton.propTypes = {
   text: PropTypes.string,
-  iconComponent: PropTypes.elementType.isRequired,
+  iconComponent: PropTypes.element.isRequired,
   theme: PropTypes.oneOf(['normal', 'photography', 'transparent', 'index']),
   disabled: PropTypes.bool,
   active: PropTypes.bool,

--- a/packages/react-components/src/button/components/pillButton.js
+++ b/packages/react-components/src/button/components/pillButton.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Arrow } from '../../icon'
 import { P1, P2 } from '../../text/paragraph'
 // utils
 import {
@@ -42,10 +41,10 @@ const ButtonContainer = styled.div`
 
 const PillButton = ({
   text = '',
+  iconComponent,
   size = 'S',
   theme = 'normal',
   type = 'primary',
-  withIcon = false,
   disabled = false,
 }) => {
   const themeFunc =
@@ -55,7 +54,6 @@ const PillButton = ({
     disabled
   )
   const { padding, iconSize } = getSizeStyle(size)
-  const iconJSX = withIcon ? <Arrow direction="right" /> : ''
   const textJSX =
     size === 'S' ? (
       <P2 text={text} weight="bold" />
@@ -73,16 +71,16 @@ const PillButton = ({
       hoverBgColor={hoverBgColor}
     >
       {textJSX}
-      {iconJSX}
+      {iconComponent}
     </ButtonContainer>
   )
 }
 PillButton.propTypes = {
+  iconComponent: PropTypes.element,
   text: PropTypes.string,
   size: PropTypes.oneOf(['S', 'L']),
   theme: PropTypes.oneOf(['transparent', 'normal', 'photography', 'index']),
   type: PropTypes.oneOf(['primary', 'secondary']),
-  withIcon: PropTypes.bool,
   disabled: PropTypes.bool,
 }
 

--- a/packages/react-components/src/button/stories/pillButton.stories.js
+++ b/packages/react-components/src/button/stories/pillButton.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PillButton from '../components/pillButton'
+import { Arrow } from '../../icon'
 
 export default {
   title: 'Button/Pill Button',
@@ -14,6 +15,15 @@ pillButton.args = {
   size: 'S',
   theme: 'normal',
   type: 'primary',
-  withIcon: true,
+  disabled: false,
+}
+
+export const withArrowIcon = Template.bind({})
+withArrowIcon.args = {
+  iconComponent: <Arrow direction="right" />,
+  text: '文字',
+  size: 'S',
+  theme: 'normal',
+  type: 'primary',
   disabled: false,
 }


### PR DESCRIPTION
- pillButton: add `iconComponent` prop
- iconButton, iconWithTextButton: fix iconComponent propTypes
- bookmark-list/empty-guide: fix style

Note: After discuss with designer, pillButton should accept different icon, thus change pillButton's spec in this patch.