### PR TITLE
Jason/fix reflow issue

### DIFF
--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -339,8 +339,8 @@ export default class Article extends PureComponent {
 
   componentWillUnmount() {
     window.removeEventListener('scroll', this.onScroll)
-    this.lastKnownScrollPosition = 0
-    this.ticking = false
+    this.lastKnownScrollPosition = null
+    this.ticking = null
     this.scrollPosition = {
       y: 0,
     }

--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -24,13 +24,11 @@ import mq from '@twreporter/core/lib/utils/media-query'
 import get from 'lodash/get'
 import map from 'lodash/map'
 import merge from 'lodash/merge'
-import throttle from 'lodash/throttle'
 
 const _ = {
   get,
   map,
   merge,
-  throttle,
 }
 
 const fontFamilyCss = css`
@@ -326,21 +324,23 @@ export default class Article extends PureComponent {
     super(props)
 
     this.mobileAsideRef = React.createRef()
+    this.lastKnownScrollPosition = 0
+    this.ticking = false
     this.scrollPosition = {
       y: 0,
     }
+    this.onScroll = this._onScroll.bind(this)
     this.toggleMobileAside = this._toggleMobileAside.bind(this)
-    this.onScroll = _.throttle(this.toggleMobileAside, 300).bind(this)
   }
 
   componentDidMount() {
-    // detect sroll position
     window.addEventListener('scroll', this.onScroll)
   }
 
   componentWillUnmount() {
     window.removeEventListener('scroll', this.onScroll)
-
+    this.lastKnownScrollPosition = 0
+    this.ticking = false
     this.scrollPosition = {
       y: 0,
     }
@@ -386,13 +386,27 @@ export default class Article extends PureComponent {
   }
 
   /**
+   * Wrap toggleMobileAside() with requestAnimationFrame() to avoid triggering browser reflow due to reading window.scrollY.
+   * ref: https://developer.mozilla.org/en-US/docs/web/api/document/scroll_event#Example
+   */
+  _onScroll() {
+    this.lastKnownScrollPosition = window.scrollY
+    if (!this.ticking) {
+      window.requestAnimationFrame(() => {
+        this.toggleMobileAside(this.lastKnownScrollPosition)
+        this.ticking = false
+      })
+      this.ticking = true
+    }
+  }
+
+  /**
    * If users scroll up, and the scrolling distance is more than a certain distance as well, show mobile aside.
    * Otherwise, if users scroll down, hide the mobile aside.
    */
-  _toggleMobileAside() {
+  _toggleMobileAside(currentTopY) {
     if (this.mobileAsideRef) {
       const mAside = this.mobileAsideRef
-      const currentTopY = window.scrollY
 
       // Calculate scrolling distance to determine whether to display aside
       const lastY = this.scrollPosition.y

--- a/packages/universal-header/src/containers/header.js
+++ b/packages/universal-header/src/containers/header.js
@@ -92,8 +92,8 @@ class Container extends React.PureComponent {
 
   componentWillUnmount() {
     window.removeEventListener('scroll', this.handleScroll)
-    this.lastKnownPageYOffset = 0
-    this.ticking = false
+    this.lastKnownPageYOffset = null
+    this.ticking = null
     this.handleScroll = null
     this.currentY = null
     this.readyY = null

--- a/packages/universal-header/src/containers/header.js
+++ b/packages/universal-header/src/containers/header.js
@@ -16,12 +16,10 @@ import mq from '@twreporter/core/lib/utils/media-query'
 // lodash
 import get from 'lodash/get'
 import map from 'lodash/map'
-import throttle from 'lodash/throttle'
 
 const _ = {
   get,
   map,
-  throttle,
 }
 
 const HIDE_HEADER_THRESHOLD = 46
@@ -77,7 +75,9 @@ class Container extends React.PureComponent {
       toUseNarrow: false,
       hideHeader: false,
     }
-    this.handleScroll = _.throttle(this.__handleScroll, 450).bind(this)
+    this.lastKnownPageYOffset = 0
+    this.ticking = false
+    this.handleScroll = this.__handleScroll.bind(this)
 
     // Below parameters are used to calculate scroll transform status.
     this.currentY = 0
@@ -92,6 +92,8 @@ class Container extends React.PureComponent {
 
   componentWillUnmount() {
     window.removeEventListener('scroll', this.handleScroll)
+    this.lastKnownPageYOffset = 0
+    this.ticking = false
     this.handleScroll = null
     this.currentY = null
     this.readyY = null
@@ -99,11 +101,24 @@ class Container extends React.PureComponent {
     this.transformTimer = null
   }
 
-  __handleScroll(event) {
-    const currentScrollTop = window.pageYOffset
+  /**
+   * Wrap __handleScroll() with requestAnimationFrame() to avoid triggering browser reflow due to reading window.pageYOffset.
+   * ref: https://developer.mozilla.org/en-US/docs/web/api/document/scroll_event#Example
+   */
+  __handleScroll() {
+    this.lastKnownPageYOffset = window.pageYOffset
+    if (!this.ticking) {
+      window.requestAnimationFrame(() => {
+        this.__updateScrollState(this.lastKnownPageYOffset)
+        this.ticking = false
+      })
+      this.ticking = true
+    }
+  }
+
+  __updateScrollState(currentScrollTop) {
     const scrollDirection = currentScrollTop > this.currentY ? 'down' : 'up'
     this.currentY = currentScrollTop
-
     const updateState = this.__getScrollState(currentScrollTop, scrollDirection)
     this.setState(updateState)
   }


### PR DESCRIPTION
白頁初步判斷是某些行為引發forced synchronous layouts(layout thrashing or reflow) [ref](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)，使效能較差的平台(i.e. mobile + safari)在文章頁會明顯看見比較長時間的空白:

1. [已刪除]progress bar(scroll顯示進度條): scroll時呼叫getBoundingClientRect(), [ref](https://stackoverflow.com/questions/13234214/reflow-layout-performance-for-large-application)

2. mobile aside(向下scroll顯示bookmark): scroll時讀取window.scrollY
<img width="1440" alt="Screen Shot 2022-05-26 at 11 43 12 PM" src="https://user-images.githubusercontent.com/25971696/170900826-58f3809b-fe15-4cd6-a12f-aa92c54e5d14.png">


3. header(向上/下scroll顯示/隱藏header): scroll時讀取window.pageYOffset
<img width="1440" alt="截圖 2022-05-25 下午11 11 57" src="https://user-images.githubusercontent.com/25971696/170878923-e8722cdc-eb18-47d2-9778-f3781016ee3f.png">

4. 還有一種行為會引發layout, 但觸發點還未找到
<img width="1440" alt="Screen Shot 2022-05-27 at 10 56 37 PM" src="https://user-images.githubusercontent.com/25971696/170878903-df9ee315-0918-4f75-a531-42ba83dd542c.png">


2, 3之解法: 用requestAnimationFrame() 
https://www.html5rocks.com/en/tutorials/speed/animations/
https://developer.mozilla.org/en-US/docs/web/api/document/scroll_event#Example
https://codertw.com/%E7%A8%8B%E5%BC%8F%E8%AA%9E%E8%A8%80/692855/#outline__3_2_1
https://yonatankra.com/layout-reflow/