### PR TITLE
fix: add prop types

### DIFF
--- a/packages/react-article-components/src/components/body/embedded-code.js
+++ b/packages/react-article-components/src/components/body/embedded-code.js
@@ -15,6 +15,24 @@ const _ = {
   merge,
 }
 
+const Embed = ({ className, children }) => (
+  <div className={className}>{children}</div>
+)
+Embed.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+}
+const StyledEmbed = styled(Embed)`
+  display: flex;
+  justify-content: center;
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`
+
 export const Block = styled.div`
   position: relative;
 
@@ -122,13 +140,15 @@ export default class EmbeddedCode extends React.PureComponent {
       {}
     )
     return (
-      <div className={className}>
-        <Block
-          ref={this._embedded}
-          dangerouslySetInnerHTML={{ __html: embeddedCodeWithoutScript }}
-        />
-        {caption ? <Caption>{caption}</Caption> : null}
-      </div>
+      <StyledEmbed className={className}>
+        <Container>
+          <Block
+            ref={this._embedded}
+            dangerouslySetInnerHTML={{ __html: embeddedCodeWithoutScript }}
+          />
+          {caption ? <Caption>{caption}</Caption> : null}
+        </Container>
+      </StyledEmbed>
     )
   }
 }

--- a/packages/react-article-components/src/components/body/embedded-code.js
+++ b/packages/react-article-components/src/components/body/embedded-code.js
@@ -23,14 +23,10 @@ Embed.propTypes = {
   children: PropTypes.node,
 }
 const StyledEmbed = styled(Embed)`
-  display: flex;
-  justify-content: center;
-`
-
-const Container = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
-  width: 100%;
+  justify-content: center;
 `
 
 export const Block = styled.div`
@@ -141,13 +137,11 @@ export default class EmbeddedCode extends React.PureComponent {
     )
     return (
       <StyledEmbed className={className}>
-        <Container>
-          <Block
-            ref={this._embedded}
-            dangerouslySetInnerHTML={{ __html: embeddedCodeWithoutScript }}
-          />
-          {caption ? <Caption>{caption}</Caption> : null}
-        </Container>
+        <Block
+          ref={this._embedded}
+          dangerouslySetInnerHTML={{ __html: embeddedCodeWithoutScript }}
+        />
+        {caption ? <Caption>{caption}</Caption> : null}
       </StyledEmbed>
     )
   }


### PR DESCRIPTION
fix [jira #397](https://twreporter-org.atlassian.net/browse/TWREPORTER-397):

1. 先把embed水平置中並撐開width
2. 如同之前用template請編輯設定高度後存入keystone, template小修改為:

`<div style='width:100%;aspect-ratio:寬/高;position:relative;'>`
`<iframe width='100%' height='100%' scrolling='no' src='http://網址' frameborder='0' webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>`

ex: 

`<div style='width:100%;aspect-ratio:560/314;position:relative;'>`
`<iframe width='100%' height='100%' scrolling='no' src='https://www.facebook.com/plugins/video.php?height=314&href=https%3A%2F%2Fwww.facebook.com%2Ftwreporter%2Fvideos%2F1832679926979871%2F&show_text=false&width=560&t=0' frameborder='0' webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>`