### PR TITLE
fix: fix empty subcategory part

### DIFF
--- a/packages/react-article-components/src/components/aside/metadata.js
+++ b/packages/react-article-components/src/components/aside/metadata.js
@@ -354,10 +354,12 @@ class Metadata extends PureComponent {
                     set?.category?.name,
                     true
                   )}
-                  {genLink(
-                    `/tags/${set?.subcategory?.id}`,
-                    set?.subcategory?.name
-                  )}
+                  {set?.subcategory?.id && set?.subcategory?.name
+                    ? genLink(
+                        `/tags/${set.subcategory.id}`,
+                        set.subcategory.name
+                      )
+                    : genLink(`/categories/${set?.category?.id}`, '全部')}
                 </LinkContainer>
               )
             })


### PR DESCRIPTION
修正 [jira #328](https://twreporter-org.atlassian.net/browse/TWREPORTER-328): 如果沒有子分類，應該要顯示`全部`，並且點擊後連結到主分類