### PR TITLE
refactor(react-article-components): set embeded code z-index

### DIFF
--- a/packages/react-article-components/src/constants/position-z-index.js
+++ b/packages/react-article-components/src/constants/position-z-index.js
@@ -4,4 +4,8 @@ export default {
   // Set z-index to 1002 because web-push has z-index 1001,
   // And header has z-index 1000.
   toc: 1002,
+  // embeded code
+  // when z-index is escalated, it is above toolbar
+  // but under the header hamburger menu which has z-index 1000
+  embed: 999,
 }


### PR DESCRIPTION
Address [TWREPORTER-420](https://twreporter-org.atlassian.net/browse/TWREPORTER-420)

This patch updates embeded code block z-index for embeded code from
@twreporter packages to let components in @twreporter/orangutan-monorepo
on top of toolbar.