### PR TITLE
chore(core): disable feature toggle for new info structure

### DIFF
--- a/packages/core/src/constants/feature-flag.js
+++ b/packages/core/src/constants/feature-flag.js
@@ -1,1 +1,1 @@
-export const ENABLE_NEW_INFO_ARCH = true
+export const ENABLE_NEW_INFO_ARCH = false


### PR DESCRIPTION
This patch disables feature toggle for new info structure to test other feature in staging.