### PR TITLE
refactor: update font 'Noto Serif TC' to 'source-han-serif-tc'

### DIFF
--- a/packages/core/src/constants/font.js
+++ b/packages/core/src/constants/font.js
@@ -1,5 +1,5 @@
 const merriweather = 'merriweather'
-const notoSerifTC = 'Noto Serif TC'
+const sourceHanSerifTC = 'source-han-serif-tc'
 const serif = 'serif'
 const rosario = 'rosario'
 const notoSansTC = 'Noto Sans TC'
@@ -7,7 +7,7 @@ const sansSerif = 'sans-serif'
 
 const fonts = {
   merriweather,
-  notoSerifTC,
+  sourceHanSerifTC,
   serif,
   rosario,
   notoSansTC,
@@ -21,7 +21,7 @@ const fontWeight = {
 }
 
 const fontFamily = {
-  title: `${merriweather}, ${notoSerifTC}, ${serif}`,
+  title: `${merriweather}, ${sourceHanSerifTC}, ${serif}`,
   default: `${rosario}, ${notoSansTC}, ${sansSerif}`,
   // use defaultFallback before ${notoSansTC} is fully loaded
   defaultFallback: `${rosario}, ${sansSerif}`,


### PR DESCRIPTION
Address [Reduce unused CSS: google font CSS link](https://app.asana.com/0/0/1202942985879129/f)

This patch updates the font 'Noto Serif TC' to 'source-han-serif-tc' since the third party web fonts changes from google font to adobe font due to performance issue (suggested by PageSpeed Insights).