### PR TITLE
fix: storybook missing config

### DIFF
--- a/packages/react-components/.storybook/preview.js
+++ b/packages/react-components/.storybook/preview.js
@@ -1,3 +1,4 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { addons } from '@storybook/addons'
 import {
   UPDATE_GLOBALS,


### PR DESCRIPTION
The storybook can't show any content and continuously loading.
I found that the console in dev tool show the error message `Uncaught ReferenceError: INITIAL_VIEWPORTS is not defined`

Because `INITIAL_VIEWPORTS` is removed in #313, the config can't be loaded correctly