### PR TITLE
feat: add explicit width, height to image

### DIFF
--- a/packages/index-page/src/components/category-section.js
+++ b/packages/index-page/src/components/category-section.js
@@ -173,6 +173,8 @@ class Category extends React.PureComponent {
                   useTinyImg ? 'tiny' : 'mobile',
                   'url',
                 ])}
+                width={_.get(imgObj, 'resized_targets.mobile.width')}
+                height={_.get(imgObj, 'resized_targets.mobile.height')}
                 srcSet={_.get(imgObj, 'resized_targets')}
                 sizes={
                   `(min-width: ${desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/common-utils/img-wrapper.js
+++ b/packages/index-page/src/components/common-utils/img-wrapper.js
@@ -65,7 +65,7 @@ class ImgWrapper extends React.Component {
   }
 
   render() {
-    const { src, alt, srcSet, sizes } = this.props
+    const { src, alt, srcSet, sizes, width, height } = this.props
     const isObjectFit = this.state.isObjectFit
     return isObjectFit ? (
       <ImgObjectFit>
@@ -77,6 +77,8 @@ class ImgWrapper extends React.Component {
           style={{
             transform: 'translateZ(0)',
           }}
+          width={width}
+          height={height}
         />
         {this.props.children}
       </ImgObjectFit>
@@ -102,6 +104,8 @@ ImgWrapper.propTypes = {
   src: PropTypes.string.isRequired,
   srcSet: PropTypes.object,
   sizes: PropTypes.string,
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
 }
 
 export default ImgWrapper

--- a/packages/index-page/src/components/editor-picks-mobile.js
+++ b/packages/index-page/src/components/editor-picks-mobile.js
@@ -119,6 +119,8 @@ class EditorPicksMobile extends SwipableMixin {
             <ImgWrapper
               alt={_.get(imgObj, 'description')}
               src={_.get(imgObj, 'resized_targets.mobile.url')}
+              width={_.get(imgObj, 'resized_targets.mobile.width')}
+              height={_.get(imgObj, 'resized_targets.mobile.height')}
               srcSet={_.get(imgObj, 'resized_targets')}
               sizes={
                 `(min-width: ${breakPoints.desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/editor-picks.js
+++ b/packages/index-page/src/components/editor-picks.js
@@ -419,6 +419,8 @@ class EditorPicks extends React.Component {
                 <ImgWrapper
                   alt={_.get(imgObj, 'description')}
                   src={_.get(imgObj, 'resized_targets.tablet.url')}
+                  width={_.get(imgObj, 'resized_targets.mobile.width')}
+                  height={_.get(imgObj, 'resized_targets.mobile.height')}
                   srcSet={_.get(imgObj, 'resized_targets')}
                   sizes={
                     `(min-width: ${breakPoints.desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/infographic-section.js
+++ b/packages/index-page/src/components/infographic-section.js
@@ -193,6 +193,8 @@ class Infographic extends React.PureComponent {
             <ImgWrapper
               alt={imgObj.alt}
               src={imgObj.src}
+              width={_.get(imgObj, 'srcSet.mobile.width')}
+              height={_.get(imgObj, 'srcSet.mobile.height')}
               srcSet={imgObj.srcSet}
               sizes={
                 `(min-width: ${breakPoints.desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/latest-section-old.js
+++ b/packages/index-page/src/components/latest-section-old.js
@@ -158,6 +158,8 @@ class LatestSection extends React.Component {
               <ImgWrapper
                 alt={_.get(imgObj, 'description')}
                 src={_.get(imgObj, 'resized_targets.mobile.url')}
+                width={_.get(imgObj, 'resized_targets.mobile.width')}
+                height={_.get(imgObj, 'resized_targets.mobile.height')}
                 srcSet={_.get(imgObj, 'resized_targets')}
                 sizes={
                   `(min-width: ${desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/latest-section.js
+++ b/packages/index-page/src/components/latest-section.js
@@ -157,9 +157,7 @@ class LatestSection extends React.Component {
         'category_set[0].subcategory.name',
         ''
       )
-      const categorySetName = `${categoryName}/${
-        subcategoryName || '全部'
-      }`
+      const categorySetName = `${categoryName}/${subcategoryName || '全部'}`
       return (
         <ItemFrame key={_.get(item, 'id')}>
           <TRLink href={href} redirect={isExternal}>
@@ -167,6 +165,8 @@ class LatestSection extends React.Component {
               <ImgWrapper
                 alt={_.get(imgObj, 'description')}
                 src={_.get(imgObj, 'resized_targets.mobile.url')}
+                width={_.get(imgObj, 'resized_targets.mobile.width')}
+                height={_.get(imgObj, 'resized_targets.mobile.height')}
                 srcSet={_.get(imgObj, 'resized_targets')}
                 sizes={
                   `(min-width: ${desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/latest-topic.js
+++ b/packages/index-page/src/components/latest-topic.js
@@ -208,6 +208,8 @@ class LatestTopic extends React.PureComponent {
                   useTinyImg ? 'tiny' : 'mobile',
                   'url',
                 ])}
+                width={_.get(imgObj, 'resized_targets.mobile.width')}
+                height={_.get(imgObj, 'resized_targets.mobile.height')}
                 srcSet={_.get(imgObj, 'resized_targets')}
                 sizes={
                   `(min-width: ${breakPoints.desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/photography-section.js
+++ b/packages/index-page/src/components/photography-section.js
@@ -169,6 +169,8 @@ class Photography extends React.PureComponent {
             <ImgWrapper
               alt={imgObj.alt}
               src={imgObj.src}
+              width={_.get(imgObj, 'srcSet.mobile.width')}
+              height={_.get(imgObj, 'srcSet.mobile.height')}
               srcSet={imgObj.srcSet}
               sizes={
                 `(min-width: ${breakPoints.desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/reviews.js
+++ b/packages/index-page/src/components/reviews.js
@@ -166,6 +166,8 @@ class Reviews extends React.PureComponent {
                   useTinyImg ? 'tiny' : 'mobile',
                   'url',
                 ])}
+                width={_.get(imgObj, 'resized_targets.mobile.width')}
+                height={_.get(imgObj, 'resized_targets.mobile.height')}
                 srcSet={_.get(imgObj, 'resized_targets')}
                 sizes={
                   `(min-width: ${desktopMinWidth}) ${mockup.img.sizes.desktop}, ` +

--- a/packages/index-page/src/components/topics-section.js
+++ b/packages/index-page/src/components/topics-section.js
@@ -216,6 +216,8 @@ class MobileTopic extends React.PureComponent {
               alt={imgObj.alt}
               srcSet={imgObj.srcSet}
               sizes={sizesForsrcSet}
+              width={_.get(imgObj, 'srcSet.mobile.width')}
+              height={_.get(imgObj, 'srcSet.mobile.height')}
             />
           </Mobile.Img>
           <Mobile.DescFrame>
@@ -315,6 +317,8 @@ class TopicsInARow extends React.PureComponent {
                 useTinyImg ? 'tiny' : 'mobile',
                 'url',
               ])}
+              width={_.get(imgObj, 'resized_targets.mobile.width')}
+              height={_.get(imgObj, 'resized_targets.mobile.height')}
               srcSet={_.get(imgObj, 'resized_targets', '')}
               sizes={sizesForsrcSet}
             />

--- a/packages/react-article-components/src/components/img-with-placeholder/index.js
+++ b/packages/react-article-components/src/components/img-with-placeholder/index.js
@@ -57,6 +57,7 @@ const Placeholder = styled.div`
 
 const ImgWithObjectFit = styled.img`
   display: block;
+  width: 100%;
   height: 100%;
   object-fit: ${props => props.objectFit || 'none'};
   object-position: ${props => props.objectPosition || '50% 50%'};
@@ -83,9 +84,11 @@ const ImgBox = styled.div`
   height: 100%;
   opacity: ${props => (props.toShow ? '1' : '0')};
   transition: opacity 0.5s;
-  & > img {
-    width: 100%;
-  }
+`
+
+const DefaultImg = styled.img`
+  width: 100%;
+  height: auto;
 `
 
 /**
@@ -240,8 +243,9 @@ export default class Img extends React.PureComponent {
 
     const srcset = getSrcsetString(imageSet)
     const isObjectFit = Boolean(objectFit)
-    const heightWidthRatio =
-      _.get(defaultImage, 'height') / _.get(defaultImage, 'width')
+    const defaultImageHeight = _.get(defaultImage, 'height')
+    const defaultImageWidth = _.get(defaultImage, 'width')
+    const heightWidthRatio = defaultImageHeight / defaultImageWidth
     if (isObjectFit && !heightWidthRatio) {
       console.warn(
         'Warning on Img component:',
@@ -275,6 +279,8 @@ export default class Img extends React.PureComponent {
                 src={defaultImageSrc}
                 srcSet={this._supportObjectFit ? srcset : ''}
                 hide={!this._supportObjectFit}
+                width={defaultImageWidth}
+                height={defaultImageHeight}
                 {...imgProps}
               />
               {this._supportObjectFit ? null : (
@@ -286,13 +292,15 @@ export default class Img extends React.PureComponent {
               )}
             </React.Fragment>
           ) : (
-            <img
+            <DefaultImg
               alt={alt}
               onLoad={this.handleImageLoaded}
               ref={this._img}
               sizes={sizes}
               src={defaultImageSrc}
               srcSet={srcset}
+              width={defaultImageWidth}
+              height={defaultImageHeight}
               {...imgProps}
             />
           )}


### PR DESCRIPTION
Issue: [Set an explicit width, height and aspect-ratio on image elements](https://app.asana.com/0/0/1202942985879133/f)

According to page speed insights, there is a diagnostic that suggest to set explicit width, height on image elements.

![image](https://user-images.githubusercontent.com/6375655/198880168-f51e908b-80ad-4161-acac-f2c59ae850fc.png)

This is what this PR does. We can set the width and height of mobile image as the default value for image elements.
And since we adjust the width and height to fit its containers by css (e.g. width="100%"), it still keeps the aspect ratio of images, like:

![image](https://user-images.githubusercontent.com/6375655/198880287-6f842bdf-966a-448f-be4f-96c143acd0f1.png)

And the computed width and height of an image is subject to the customized css style (e.g. the value computed by width="100%").


