### PR TITLE
fix: category politics and society path typo

### DIFF
--- a/packages/core/src/constants/category-set.js
+++ b/packages/core/src/constants/category-set.js
@@ -1,7 +1,7 @@
 const categoryPath = {
   world: 'world',
   humanrights: 'humanrights',
-  politicsAndSociety: 'politics-and-society',
+  politicsAndSociety: 'politics_and_society',
   health: 'health',
   environment: 'environment',
   econ: 'econ',

--- a/packages/core/src/constants/category-set.js
+++ b/packages/core/src/constants/category-set.js
@@ -1,7 +1,7 @@
 const categoryPath = {
   world: 'world',
   humanrights: 'humanrights',
-  politicsAndSociety: 'politics_and_society',
+  politicsAndSociety: 'politics-and-society',
   health: 'health',
   environment: 'environment',
   econ: 'econ',

--- a/packages/react-components/src/listing-page/components/list.js
+++ b/packages/react-components/src/listing-page/components/list.js
@@ -24,7 +24,7 @@ const _ = {
 }
 
 const Container = styled.div`
-  margin: 45px auto 0 auto;
+  margin: 0 auto;
 `
 
 const Header = styled.div`

--- a/packages/redux/src/reducers/__test__/index-page.test.js
+++ b/packages/redux/src/reducers/__test__/index-page.test.js
@@ -4,6 +4,13 @@ import fieldNames from '../../constants/redux-state-field-names'
 import reducer from '../index-page'
 import types from '../../constants/action-types'
 import { ENABLE_NEW_INFO_ARCH } from '@twreporter/core/lib/constants/feature-flag'
+// lodash
+import reduce from 'lodash/reduce'
+import snakeCase from 'lodash/snakeCase'
+const _ = {
+  reduce,
+  snakeCase,
+}
 
 const post1 = {
   id: 'post-id-1',
@@ -38,6 +45,21 @@ const nonFullTopic = {
   full: false,
 }
 
+const unifyToBeFieldName = fields =>
+  _.reduce(
+    fields,
+    (res, value, key) => {
+      res[key] = _.snakeCase(value)
+      return res
+    },
+    {}
+  )
+
+const beFieldNames = {
+  categories: unifyToBeFieldName(fieldNames.categories),
+  sections: unifyToBeFieldName(fieldNames.sections),
+}
+
 describe('index-page reducer', () => {
   test('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({
@@ -50,22 +72,22 @@ describe('index-page reducer', () => {
   test('should handle `types.indexPage.read.success`', () => {
     const categoryPayload = ENABLE_NEW_INFO_ARCH
       ? {
-          [fieldNames.categories.world]: [post1],
-          [fieldNames.categories.humanrights]: [post2],
-          [fieldNames.categories.politicsAndSociety]: [post3],
-          [fieldNames.categories.health]: [post4],
-          [fieldNames.categories.environment]: [],
-          [fieldNames.categories.econ]: [],
-          [fieldNames.categories.culture]: [],
-          [fieldNames.categories.education]: [],
+          [beFieldNames.categories.world]: [post1],
+          [beFieldNames.categories.humanrights]: [post2],
+          [beFieldNames.categories.politicsAndSociety]: [post3],
+          [beFieldNames.categories.health]: [post4],
+          [beFieldNames.categories.environment]: [],
+          [beFieldNames.categories.econ]: [],
+          [beFieldNames.categories.culture]: [],
+          [beFieldNames.categories.education]: [],
         }
       : {
-          [fieldNames.categories.humanRightsAndSociety]: [post1],
-          [fieldNames.categories.environmentAndEducation]: [post2],
-          [fieldNames.categories.politicsAndEconomy]: [post3],
-          [fieldNames.categories.cultureAndArt]: [post4],
-          [fieldNames.categories.livingAndMedicalCare]: [],
-          [fieldNames.categories.international]: [],
+          [beFieldNames.categories.humanRightsAndSociety]: [post1],
+          [beFieldNames.categories.environmentAndEducation]: [post2],
+          [beFieldNames.categories.politicsAndEconomy]: [post3],
+          [beFieldNames.categories.cultureAndArt]: [post4],
+          [beFieldNames.categories.livingAndMedicalCare]: [],
+          [beFieldNames.categories.international]: [],
         }
     const categoryResponse = ENABLE_NEW_INFO_ARCH
       ? {
@@ -95,13 +117,13 @@ describe('index-page reducer', () => {
           type: types.indexPage.read.success,
           payload: {
             items: {
-              [fieldNames.sections.latestSection]: [post1],
-              [fieldNames.sections.editorPicksSection]: [post2],
-              [fieldNames.sections.reviewsSection]: [post3],
-              [fieldNames.sections.latestTopicSection]: [fullTopic],
-              [fieldNames.sections.topicsSection]: [fullTopic, nonFullTopic],
-              [fieldNames.sections.photosSection]: [post4],
-              [fieldNames.sections.infographicsSection]: [],
+              [beFieldNames.sections.latestSection]: [post1],
+              [beFieldNames.sections.editorPicksSection]: [post2],
+              [beFieldNames.sections.reviewsSection]: [post3],
+              [beFieldNames.sections.latestTopicSection]: [fullTopic],
+              [beFieldNames.sections.topicsSection]: [fullTopic, nonFullTopic],
+              [beFieldNames.sections.photosSection]: [post4],
+              [beFieldNames.sections.infographicsSection]: [],
               ...categoryPayload,
             },
           },

--- a/packages/redux/src/reducers/index-page.js
+++ b/packages/redux/src/reducers/index-page.js
@@ -7,13 +7,14 @@ import get from 'lodash/get'
 import map from 'lodash/map'
 import merge from 'lodash/merge'
 import values from 'lodash/values'
-
+import snakeCase from 'lodash/snakeCase'
 const _ = {
   concat,
   get,
   map,
   merge,
   values,
+  snakeCase,
 }
 
 const initialState = {
@@ -33,7 +34,8 @@ function indexPage(state = initialState, action = {}) {
       const fields = _.concat(sections, categories)
 
       fields.forEach(field => {
-        rtn[field] = _.map(_.get(payload, ['items', field]), post => {
+        const key = _.snakeCase(field)
+        rtn[field] = _.map(_.get(payload, ['items', key]), post => {
           return _.get(post, 'id')
         })
       })

--- a/packages/universal-header/src/components/tab-bar.js
+++ b/packages/universal-header/src/components/tab-bar.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 // context
 import HeaderContext, { HamburgerContext } from '../contexts/header-context'
 // utils
-import { getTabBarLinks } from '../utils/links'
+import { getTabBarLinks, checkPathnameParent } from '../utils/links'
 import { selectTabBarTheme } from '../utils/theme'
 // @twreporter
 import Link from '@twreporter/react-components/lib/customized-link'
@@ -54,7 +54,8 @@ const TabBar = () => {
   const HamburgerIcon = <Hamburger releaseBranch={releaseBranch} />
   const { bgColor, borderColor } = selectTabBarTheme(theme)
   const isHomeActive = !isHamburgerMenuOpen && pathname === '/'
-  const isLatestActive = !isHamburgerMenuOpen && pathname === '/latest'
+  const isLatestActive =
+    !isHamburgerMenuOpen && checkPathnameParent(pathname, 'latest')
   const isBookmarkActive = !isHamburgerMenuOpen && pathname === '/bookmarks'
   const hamburgerIconText = isHamburgerMenuOpen ? '關閉選單' : '選單'
 

--- a/packages/universal-header/src/utils/links.js
+++ b/packages/universal-header/src/utils/links.js
@@ -79,12 +79,7 @@ export const checkReferrer = (
 }
 
 export const checkPathnameParent = (pathname = '', parent = '') => {
-  try {
-    const isMatch = _.indexOf(_.split(pathname, '/'), parent) === 1
-    return isMatch
-  } catch (err) {
-    return false
-  }
+  return _.indexOf(_.split(pathname, '/'), parent) === 1
 }
 
 export const getCategoryLink = (

--- a/packages/universal-header/src/utils/links.js
+++ b/packages/universal-header/src/utils/links.js
@@ -80,7 +80,7 @@ export const checkReferrer = (
 
 export const checkPathnameParent = (pathname = '', parent = '') => {
   try {
-    const isMatch = _.split(pathname, '/')[1] === parent
+    const isMatch = _.indexOf(_.split(pathname, '/'), parent) === 1
     return isMatch
   } catch (err) {
     return false

--- a/packages/universal-header/src/utils/links.js
+++ b/packages/universal-header/src/utils/links.js
@@ -78,6 +78,15 @@ export const checkReferrer = (
   }
 }
 
+export const checkPathnameParent = (pathname = '', parent = '') => {
+  try {
+    const isMatch = _.split(pathname, '/')[1] === parent
+    return isMatch
+  } catch (err) {
+    return false
+  }
+}
+
 export const getCategoryLink = (
   isExternal = defaultIsExternal,
   releaseBranch = defaultReleaseBranch,


### PR DESCRIPTION
This patch fix following defects:
- [`[defect] 首頁議題區塊只顯示 7 個區塊，少了政治社會`](https://app.asana.com/0/0/1203964075873158/f)
- [`[defect] 主網站：分類頁的 title bar 與下面的文章 margin: tablet 應為 32px，mobile 應為 24px`](https://app.asana.com/0/0/1203964971392538/f)
- [`[defect] 主網站：最新頁的 title bar 與下面的文章 margin: tablet 應為 32px，mobile 應為 24px`](https://app.asana.com/0/0/1203964971392530/f)
- [`[defect] 最新頁：在最新頁點選其他時事時，tab bar 的最新 tab 應該要 active state（變成紅色）`](https://app.asana.com/0/0/1203964971392539/f)