### PR TITLE
fix: fix category link issue & add error handling

### DIFF
--- a/packages/core/src/constants/category-set.js
+++ b/packages/core/src/constants/category-set.js
@@ -54,6 +54,14 @@ export const CATEGORY_ID = {
   [categoryPath.photography]: '574d028748fa171000c45d48',
 }
 
+// flip CATEGORY_ID to a {id: path} object
+const flippedCategoryID = Object.fromEntries(
+  Object.entries(CATEGORY_ID).map(([key, value]) => [value, key])
+)
+export const GET_CATEGORY_PATH_FROM_ID = id => {
+  return flippedCategoryID[id]
+}
+
 const subcategoryPath = {
   all: 'all',
   hk: 'hk',
@@ -326,6 +334,7 @@ export default {
   CATEGORY_ORDER,
   CATEGORY_LABEL,
   CATEGORY_ID,
+  GET_CATEGORY_PATH_FROM_ID,
   SUBCATEGORY_LABEL,
   SUBCATEGORY_ID,
   CATEGORY_SET,

--- a/packages/react-article-components/src/components/aside/metadata.js
+++ b/packages/react-article-components/src/components/aside/metadata.js
@@ -15,6 +15,7 @@ import { idToPathSegment } from '../../constants/category'
 import mq from '@twreporter/core/lib/utils/media-query'
 import { ARTICLE_THEME } from '@twreporter/core/lib/constants/theme'
 import { COLOR_ARTICLE } from '@twreporter/core/lib/constants/color'
+import { GET_CATEGORY_PATH_FROM_ID } from '@twreporter/core/lib/constants/category-set'
 import { ENABLE_NEW_INFO_ARCH } from '@twreporter/core/lib/constants/feature-flag'
 import TextLink from '@twreporter/react-components/lib/text/link'
 
@@ -293,14 +294,15 @@ const CategorySet = props => {
         </CategorySetFlex>
       )
     }
-    return (
+    const categoryPath = GET_CATEGORY_PATH_FROM_ID(set?.category?.id)
+    return categoryPath ? (
       <LinkContainer key={`categorySet-${index}`}>
-        {genLink(`/categories/${set?.category?.id}`, set?.category?.name, true)}
+        {genLink(`/categories/${categoryPath}`, set?.category?.name, true)}
         {set?.subcategory?.id && set?.subcategory?.name
           ? genLink(`/tags/${set.subcategory.id}`, set.subcategory.name)
-          : genLink(`/categories/${set?.category?.id}`, '全部')}
+          : genLink(`/categories/${categoryPath}`, '全部')}
       </LinkContainer>
-    )
+    ) : null
   })
   return <CategorySetFlexBox>{categorySetJSX}</CategorySetFlexBox>
 }


### PR DESCRIPTION
fix
[[defect] 點擊文章頁 meta data 的分類/子分類時，無法正確跳轉到對應頁面](https://app.asana.com/0/1202961977949746/1203964075873151/f)
[[defect] keystone 設定的分類組合未完整顯示於文章頁](https://app.asana.com/0/1202961977949746/1203964075873152/f)