### PR TITLE
fix: replace Object.fromentries() to avoid version compatiblity issue

### DIFF
--- a/packages/core/src/constants/category-set.js
+++ b/packages/core/src/constants/category-set.js
@@ -55,12 +55,12 @@ export const CATEGORY_ID = {
 }
 
 // flip CATEGORY_ID to a {id: path} object
-let flippedCategoryID = {}
+let categoryIDToPath = {}
 Object.entries(CATEGORY_ID).forEach(([key, value]) => {
-  flippedCategoryID[value] = key
+  categoryIDToPath[value] = key
 })
 export const GET_CATEGORY_PATH_FROM_ID = id => {
-  return flippedCategoryID[id]
+  return categoryIDToPath[id]
 }
 
 const subcategoryPath = {

--- a/packages/core/src/constants/category-set.js
+++ b/packages/core/src/constants/category-set.js
@@ -55,9 +55,10 @@ export const CATEGORY_ID = {
 }
 
 // flip CATEGORY_ID to a {id: path} object
-const flippedCategoryID = Object.fromEntries(
-  Object.entries(CATEGORY_ID).map(([key, value]) => [value, key])
-)
+let flippedCategoryID = {}
+Object.entries(CATEGORY_ID).forEach(([key, value]) => {
+  flippedCategoryID[value] = key
+})
 export const GET_CATEGORY_PATH_FROM_ID = id => {
   return flippedCategoryID[id]
 }


### PR DESCRIPTION
twreporter-react升級node到16除了要改circle ci config外應該還要改其他地方, 而且最好需要測試, 而且url.parse那個warning改掉後routing會有問題, 還需要其他處理, 先把Object.fromentries替換成相容的寫法