### PR TITLE
fix: mobile header logo align center

### DIFF
--- a/packages/universal-header/src/components/header.js
+++ b/packages/universal-header/src/components/header.js
@@ -127,6 +127,9 @@ const MobileLogoContainer = styled.div`
   img {
     height: 21px;
   }
+  a {
+    display: flex;
+  }
 `
 const HideWhenNarrow = styled.div``
 const ShowWhenNarrow = styled.div``


### PR DESCRIPTION
This patch fix [[defect] mobile header 的 logo 沒有置中](https://app.asana.com/0/1203699264568808/1203955893209717/f)