### PR TITLE
fix: add `showCategory` prop for List component

### DIFF
--- a/packages/react-components/src/listing-page/components/list.js
+++ b/packages/react-components/src/listing-page/components/list.js
@@ -74,7 +74,14 @@ const Items = FetchingWrapper(FlexItems)
 
 class List extends PureComponent {
   render() {
-    const { data, catName, tagName, isFetching, showSpinner } = this.props
+    const {
+      data,
+      catName,
+      tagName,
+      isFetching,
+      showSpinner,
+      showCategory,
+    } = this.props
     const listJSX = []
     _.forEach(data, item => {
       const style = _.get(item, 'style')
@@ -113,7 +120,9 @@ class List extends PureComponent {
               _.get(item, 'hero_image.resized_targets.mobile.url') ||
               _.get(item, 'og_image.resized_targets.mobile.url'),
           }}
-          category={_.get(item, 'categories.0.name', '')}
+          category={
+            showCategory && _.get(item, 'category_set.0.category.name', '')
+          }
           pubDate={date2yyyymmdd(_.get(item, 'published_date', ''), '.')}
           tags={tags}
           link={{
@@ -142,6 +151,7 @@ List.defaultProps = {
   tagName: '',
   isFetching: false,
   showSpinner: false,
+  showCategory: false,
 }
 
 List.propTypes = {
@@ -161,6 +171,7 @@ List.propTypes = {
   catName: PropTypes.string,
   isFetching: PropTypes.bool,
   showSpinner: PropTypes.bool,
+  showCategory: PropTypes.bool,
 }
 
 export default List


### PR DESCRIPTION
# Issue
[[defect] tag 頁的文章沒有出現文章主分類](https://app.asana.com/0/1203699264568808/1204362012792364/f)

# Notice
Same list has been used in category page which should not show `category` string, thus add `showCategory` prop to determine show or not.

# Dependency
N/A
