### PR TITLE
fix: editor pick section should show category_set info

### DIFF
--- a/packages/index-page/src/components/editor-picks-old.js
+++ b/packages/index-page/src/components/editor-picks-old.js
@@ -321,20 +321,20 @@ class EditorPicks extends React.Component {
           position: 'left',
           component: SideCategory,
           propsForComponent: { top: null, left: '10%' },
-          dataPath: 'category_set[0].category.name',
+          dataPath: 'categories[0].name',
         },
         {
           position: 'middle',
           component: MiddleCategory,
           propsForComponent: { top: '60px', left: '50%' },
-          dataPath: 'category_set[0].category.name',
+          dataPath: 'categories[0].name',
         },
         {
           position: 'right',
           middle: false,
           component: SideCategory,
           propsForComponent: { top: null, left: '90%' },
-          dataPath: 'category_set[0].category.name',
+          dataPath: 'categories[0].name',
         },
         {
           position: 'middle',

--- a/packages/index-page/src/index.js
+++ b/packages/index-page/src/index.js
@@ -1,6 +1,7 @@
 import CategorySection from './components/category-section'
 import DonationBoxSection from './components/donation-box-section'
-import EditorPicks from './components/editor-picks'
+import EditorPicksNew from './components/editor-picks'
+import EditorPicksOld from './components/editor-picks-old'
 import InforgraphicSection from './components/infographic-section'
 import JuniorBoxSection from './components/junior-box-section'
 import LatestSectionNew from './components/latest-section'
@@ -16,6 +17,7 @@ import TopicsSection from './components/topics-section'
 // feature toggle
 import { ENABLE_NEW_INFO_ARCH } from '@twreporter/core/lib/constants/feature-flag'
 const LatestSection = ENABLE_NEW_INFO_ARCH ? LatestSectionNew : LatestSectionOld
+const EditorPicks = ENABLE_NEW_INFO_ARCH ? EditorPicksNew : EditorPicksOld
 
 export default {
   components: {


### PR DESCRIPTION
# Issue
[[defect] 首頁編輯精選區塊沒有出現分類組合](https://app.asana.com/0/0/1204529009740269/f)

# Dependency
N/A
