### PR TITLE
fix: tab bar icon theme

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -20,7 +20,6 @@
     "fontfaceobserver-es": "^3.3.3",
     "hoist-non-react-statics": "^2.3.1",
     "lodash": "^4.0.0",
-    "material-symbols": "^0.5.5",
     "memoize-one": "^5.0.5",
     "prop-types": "^15.0.0",
     "react": "^16.3.0",

--- a/packages/universal-header/src/components/tab-bar.js
+++ b/packages/universal-header/src/components/tab-bar.js
@@ -5,6 +5,8 @@ import HeaderContext, { HamburgerContext } from '../contexts/header-context'
 // utils
 import { getTabBarLinks, checkPathnameParent } from '../utils/links'
 import { selectTabBarTheme } from '../utils/theme'
+// constants
+import themeConst from '../constants/theme'
 // @twreporter
 import Link from '@twreporter/react-components/lib/customized-link'
 import MaterialSymbol from '@twreporter/react-components/lib/material-icon'
@@ -52,6 +54,7 @@ const TabBar = () => {
     toggleHamburger,
     isHamburgerMenuOpen,
   } = useContext(HamburgerContext)
+  const iconTheme = theme === themeConst.photography ? theme : themeConst.normal
   const { home, latest, bookmark } = getTabBarLinks(
     isLinkExternal,
     releaseBranch
@@ -81,7 +84,7 @@ const TabBar = () => {
         <IconWithTextButton
           text="首頁"
           iconComponent={HomeIcon}
-          theme={theme}
+          theme={iconTheme}
           active={isHomeActive}
         />
       </ButtonLinkContainer>
@@ -89,7 +92,7 @@ const TabBar = () => {
         <IconWithTextButton
           text="最新"
           iconComponent={ClockIcon}
-          theme={theme}
+          theme={iconTheme}
           active={isLatestActive}
         />
       </ButtonLinkContainer>
@@ -97,7 +100,7 @@ const TabBar = () => {
         <IconWithTextButton
           text="我的書籤"
           iconComponent={BookmarkIcon}
-          theme={theme}
+          theme={iconTheme}
           active={isBookmarkActive}
         />
       </ButtonLinkContainer>
@@ -105,7 +108,7 @@ const TabBar = () => {
         <IconWithTextButton
           text={hamburgerIconText}
           iconComponent={HamburgerIcon}
-          theme={theme}
+          theme={iconTheme}
           active={isHamburgerMenuOpen}
         />
       </ButtonContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13571,11 +13571,6 @@ matcher@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.4"
 
-material-symbols@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/material-symbols/-/material-symbols-0.5.5.tgz#af44b54c39a5c89ab7ba33362cf97251373dc735"
-  integrity sha512-NFUsjEVBNZvcRRqslY0RWnmlGgjhJkpDQkQs42o52gT2AmIbaP6V7wTRgyTkLAoD5VtpgpIx9eoOAXcH2ynwkg==
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
# Issue
- fix tab bar button theme
  - `transparent` page still use `normal` theme buttons
- remove useless dependency `material-symbols`
  - import it in `twreporter-react` & `membership-fe`