### PR TITLE
fix: fix action button theme

### DIFF
--- a/packages/universal-header/src/components/action-button-item.js
+++ b/packages/universal-header/src/components/action-button-item.js
@@ -76,7 +76,8 @@ const ActionButtonItem = ({
 }) => {
   const { theme } = useContext(HeaderContext)
   const buttonTheme =
-    direction === DIRECTION_TYPE.row || theme === THEME.photography
+    (direction === DIRECTION_TYPE.row && theme !== THEME.transparent) ||
+    theme === THEME.photography
       ? theme
       : THEME.noraml
   const actionKey = action.key

--- a/packages/universal-header/src/components/action-button-item.js
+++ b/packages/universal-header/src/components/action-button-item.js
@@ -73,13 +73,19 @@ const ActionButtonItem = ({
   buttonWidth = BUTTON_WIDTH_TYPE.fit,
   buttonSize = BUTTON_SIZE_TYPE.S,
   callback = defaultFunc,
+  isForHambuger = false,
 }) => {
   const { theme } = useContext(HeaderContext)
-  const buttonTheme =
-    (direction === DIRECTION_TYPE.row && theme !== THEME.transparent) ||
-    theme === THEME.photography
-      ? theme
-      : THEME.noraml
+  let buttonTheme
+  if (isForHambuger) {
+    if (theme === THEME.transparent) {
+      buttonTheme = THEME.normal
+    } else {
+      buttonTheme = theme
+    }
+  } else {
+    buttonTheme = theme
+  }
   const actionKey = action.key
   const actionLabel = ACTION_LABEL[textType][actionKey]
   const actionLink = getActionLinks()[actionKey]
@@ -109,6 +115,7 @@ ActionButtonItem.propTypes = {
   buttonWidth: BUTTON_WIDTH_PROP_TYPE,
   buttonSize: BUTTON_SIZE_PROP_TYPE,
   callback: PropTypes.func,
+  isForHambuger: PropTypes.bool,
 }
 
 const ActionButton = ({
@@ -118,6 +125,7 @@ const ActionButton = ({
   buttonWidth = BUTTON_WIDTH_TYPE.fit,
   buttonSize = BUTTON_SIZE_TYPE.S,
   callback = defaultFunc,
+  isForHambuger = false,
   ...rest
 }) => (
   <ActionsContainer direction={direction} buttonWidth={buttonWidth} {...rest}>
@@ -130,6 +138,7 @@ const ActionButton = ({
           buttonWidth={buttonWidth}
           buttonSize={buttonSize}
           key={action.key}
+          isForHambuger={isForHambuger}
         />
       )
     })}
@@ -143,6 +152,7 @@ ActionButton.propTypes = {
   buttonWidth: ActionButtonItem.propTypes.buttonWidth,
   buttonSize: ActionButtonItem.propTypes.buttonSize,
   callback: PropTypes.func,
+  isForHambuger: PropTypes.bool,
 }
 
 export default ActionButton

--- a/packages/universal-header/src/components/action-button-item.stories.js
+++ b/packages/universal-header/src/components/action-button-item.stories.js
@@ -84,7 +84,7 @@ transparentTheme.parameters = {
 export const hamburger = props => (
   <HeaderContext.Provider value={{ theme: props.theme }}>
     <Container>
-      <ActionButton {...props} />
+      <ActionButton isForHambuger={true} {...props} />
     </Container>
   </HeaderContext.Provider>
 )

--- a/packages/universal-header/src/components/action-button.js
+++ b/packages/universal-header/src/components/action-button.js
@@ -36,6 +36,7 @@ export const DesktopHamburgerAction = ({ ...props }) => {
       textType={TEXT_TYPE.full}
       buttonWidth={BUTTON_WIDTH_TYPE.stretch}
       buttonSize={BUTTON_SIZE_TYPE.L}
+      isForHambuger={true}
       {...props}
     />
   )
@@ -49,6 +50,7 @@ export const MobileHamburgerAction = ({ ...props }) => {
       textType={TEXT_TYPE.full}
       buttonWidth={BUTTON_WIDTH_TYPE.stretch}
       buttonSize={BUTTON_SIZE_TYPE.L}
+      isForHambuger={true}
       {...props}
     />
   )


### PR DESCRIPTION
# Issue
[20230512 transparent 的 mobile sidemenu 的按鈕看不到（因為是 transparent theme，但應該用 normal 就好）](https://app.asana.com/0/1203983432530614/1204588802643715/f)

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
