### PR TITLE
fix(redux): `politics-and-society` category not shown on index page

### DIFF
--- a/packages/redux/src/reducers/entities.js
+++ b/packages/redux/src/reducers/entities.js
@@ -7,12 +7,14 @@ import concat from 'lodash/concat'
 import forEach from 'lodash/forEach'
 import get from 'lodash/get'
 import values from 'lodash/values'
+import snakeCase from 'lodash/snakeCase'
 
 const _ = {
   concat,
   forEach,
   get,
   values,
+  snakeCase,
 }
 
 const defaultState = {
@@ -90,11 +92,12 @@ function entities(state = defaultState, action = {}) {
       let posts = []
       let topics = []
       _.forEach(fieldKeys, fieldKey => {
-        const entities = _.get(action, ['payload', 'items', fieldKey])
+        const key = _.snakeCase(fieldKey)
+        const entities = _.get(action, ['payload', 'items', key])
         if (Array.isArray(entities)) {
           if (
-            fieldKey !== fieldNames.sections.latestTopicSection &&
-            fieldKey !== fieldNames.sections.topicsSection
+            key !== fieldNames.sections.latestTopicSection &&
+            key !== fieldNames.sections.topicsSection
           ) {
             posts = _.concat(posts, entities)
           } else {


### PR DESCRIPTION
# Issue
在首頁的「議題」專區，「政治社會」分類的新聞沒有出現。

請見附圖：
<img width="1486" alt="截圖 2023-07-14 上午10 36 23" src="https://github.com/twreporter/twreporter-npm-packages/assets/3000343/44e9fb5f-4adc-4960-ada0-148dab302093">

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
