### PR TITLE
fix(react-components): wrong url path for interactive posts

### DIFF
--- a/packages/react-components/src/listing-page/components/list.js
+++ b/packages/react-components/src/listing-page/components/list.js
@@ -71,7 +71,7 @@ class List extends PureComponent {
     _.forEach(data, item => {
       const style = _.get(item, 'style')
       const slug = _.get(item, 'slug')
-      const isInteractiveArticle = style === ARTICLE_THEME.interactive
+      const isInteractiveArticle = style === ARTICLE_THEME.v2.interactive
       const to = `${
         isInteractiveArticle
           ? entityPaths.interactiveArticle


### PR DESCRIPTION
### 問題
在數位敘事的 listing page ( https://www.twreporter.org/tag/630f029461ca4e07004ef530 ) 裡，多篇多媒體文章點擊後，文章沒有順利導到正確的網址；導致文章內容沒有正確呈現。


### 應該要有的行為
若該篇文章的 `style` 為 interactive 的話，其 url path 應該為 `/i/${post_slug}`，而非 `/a/${post_slug}`，而且點擊該篇文章連結時，要另開分頁。

### Bug fix
程式碼裡有 typo，導致沒有正確判斷 post style。

