### PR TITLE
fix: member role card layout

### DIFF
--- a/packages/react-components/src/mobile-member-role-card/index.js
+++ b/packages/react-components/src/mobile-member-role-card/index.js
@@ -59,6 +59,7 @@ const RelativeDiv = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
+  justify-content: space-between;
 `
 
 const FlexContainer = styled.div`


### PR DESCRIPTION
# Issue
[[defect] 會員卡的右邊標題應該靠右](https://app.asana.com/0/0/1205283044439410/f)

# Dependency
N/A
