### PR TITLE
chore: upgrade node to v18.17.1 (LTS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node-executor:
     docker:
-      - image: cimg/node:16.14.2
+      - image: cimg/node:18.17.1
     working_directory: ~/repo
     environment:
       - NODE_BIN_DIR: "node_modules/.bin"


### PR DESCRIPTION
# Issue
[[工程] upgrade nodejs to v18
](https://app.asana.com/0/1203699264568808/1204298342406882/f)

# Notice
- vercel deployment setting would also need to be updated after release

# Dependency
N/A
