### PR TITLE
fix: safari input bottom border dissapear

### DIFF
--- a/packages/react-components/src/input/components/text-field.js
+++ b/packages/react-components/src/input/components/text-field.js
@@ -31,6 +31,7 @@ const Input = styled.input`
   border-radius: 0;
   color: ${props => textColor[props.state]};
   border-color: ${props => borderColor[props.state]};
+  border-style: solid;
   &:focus,
   &:focus-visible {
     outline-width: 0;


### PR DESCRIPTION
# Issue
[[defect] safari expired state 時，text field 會消失](https://app.asana.com/0/0/1205430118369584/f)

# Dependency
N/A