### PR TITLE
feat: add `InheritLinkButton` component & story

### DIFF
--- a/packages/react-components/src/button/components/link.js
+++ b/packages/react-components/src/button/components/link.js
@@ -23,12 +23,19 @@ const style = {
   },
 }
 
-const LinkContainer = styled(Link)`
-  display: flex;
-  align-items: center;
+const BaseContainer = styled(Link)`
   text-underline-offset: 4px;
   text-decoration-line: ${props => style.decoration[props.type]};
   color: ${props => style.color[props.type]};
+
+  &:hover {
+    text-decoration-line: underline;
+  }
+`
+
+const LinkContainer = styled(BaseContainer)`
+  display: flex;
+  align-items: center;
 
   ${props =>
     props.disabled
@@ -38,11 +45,10 @@ const LinkContainer = styled(Link)`
     -webkit-tap-highlight-color: transparent;
   `
       : `
-    &:hover {
-      text-decoration-line: underline;
-    }
   `}
 `
+
+const InheritLinkContainer = styled(BaseContainer)``
 
 const LinkButton = ({
   type = LinkType.DEFAULT,
@@ -75,5 +81,22 @@ LinkButton.propTypes = {
 }
 LinkButton.Type = LinkType
 LinkButton.Weight = P1.Weight
+
+export const InheritLinkButton = ({
+  type = LinkType.DEFAULT,
+  link = {},
+  text = '',
+  ...props
+}) => (
+  <InheritLinkContainer type={type} {...props}>
+    {text}
+  </InheritLinkContainer>
+)
+InheritLinkButton.propTypes = {
+  type: PropTypes.oneOf(Object.values(LinkType)),
+  link: PropTypes.object,
+  text: PropTypes.string.isRequired,
+}
+InheritLinkButton.Type = LinkType
 
 export default LinkButton

--- a/packages/react-components/src/button/index.js
+++ b/packages/react-components/src/button/index.js
@@ -3,7 +3,7 @@ import IconButton from './components/iconButton'
 import IconWithTextButton from './components/iconWithTextButton'
 import TextButton from './components/textButton'
 import ToggleButton from './components/toggleButton'
-import LinkButton from './components/link'
+import LinkButton, { InheritLinkButton } from './components/link'
 import MenuButton from './components/menuButton'
 
 export {
@@ -13,6 +13,7 @@ export {
   TextButton,
   ToggleButton,
   LinkButton,
+  InheritLinkButton,
   MenuButton,
 }
 
@@ -23,5 +24,6 @@ export default {
   TextButton,
   ToggleButton,
   LinkButton,
+  InheritLinkButton,
   MenuButton,
 }

--- a/packages/react-components/src/button/stories/link.stories.js
+++ b/packages/react-components/src/button/stories/link.stories.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import styled from 'styled-components'
 import { getRadioArg } from '../../storybook/utils/get-enum-arg'
-import Link from '../components/link'
-import { P2 } from '../../text/paragraph'
+import Link, { InheritLinkButton } from '../components/link'
+import { P1, P2 } from '../../text/paragraph'
 import { H4 } from '../../text/headline'
 
 export default {
@@ -9,11 +10,21 @@ export default {
   component: Link,
   argTypes: {
     type: getRadioArg(Link.Type, Link.Type.DEFAULT),
+    weight: getRadioArg(Link.Weight, Link.Weight.NORMAL),
     // textComponent is only for storybook showcase, not real props
     textComponent: {
       defaultValue: 'P2',
       options: ['not assign', 'P2', 'H4'],
       control: { type: 'radio' },
+    },
+    // leftWord & rightWord is only for storybook showcase, not real props
+    leftWord: {
+      defaultValue: '連結左邊的文字',
+      control: { type: 'text' },
+    },
+    rightWord: {
+      defaultValue: '連結左邊的文字',
+      control: { type: 'text' },
     },
   },
 }
@@ -26,7 +37,9 @@ link.args = {
   type: Link.Type.DEFAULT,
   link: { to: 'https://www.twreporter.org' },
 }
-link.parameters = { controls: { exclude: ['textComponent'] } }
+link.parameters = {
+  controls: { exclude: ['textComponent', 'leftWord', 'rightWord'] },
+}
 
 export const changeTextComponent = args => {
   if (args.textComponent === 'P2') {
@@ -45,7 +58,7 @@ changeTextComponent.args = {
   link: { to: 'https://www.twreporter.org' },
 }
 changeTextComponent.parameters = {
-  controls: { exclude: ['TextComponent'] },
+  controls: { exclude: ['TextComponent', 'leftWord', 'rightWord'] },
 }
 
 export const disabledLink = Template.bind({})
@@ -56,5 +69,26 @@ disabledLink.args = {
   disabled: true,
 }
 disabledLink.parameters = {
-  controls: { exclude: ['textComponent', 'disabled'] },
+  controls: { exclude: ['textComponent', 'disabled', 'leftWord', 'rightWord'] },
+}
+
+const StyledP1 = styled(P1)`
+  display: unset;
+`
+export const linkInParagraph = args => (
+  <StyledP1>
+    {args.leftWord}
+    <InheritLinkButton {...args} />
+    {args.rightWord}
+  </StyledP1>
+)
+linkInParagraph.args = {
+  text: '文字',
+  type: Link.Type.DEFAULT,
+  link: { to: 'https://www.twreporter.org' },
+}
+linkInParagraph.parameters = {
+  controls: {
+    exclude: ['textComponent', 'disabled', 'weight', 'TextComponent'],
+  },
 }

--- a/packages/react-components/src/text/paragraph.js
+++ b/packages/react-components/src/text/paragraph.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Weight } from './enums'
 import { fontWeight, fontFamily } from '@twreporter/core/lib/constants/font'
 
-const defaultContainer = styled.div`
+const defaultContainer = styled.p`
   font-weight: ${props => fontWeight[props.weight]};
   font-family: ${fontFamily.default};
   line-height: 150%;


### PR DESCRIPTION
# Issue
[[維運] 會員頁-電子報設定新增「少年報導者」
](https://app.asana.com/0/1203699264568808/1205728019440902/f)

# Notice
- add `InheritLinkButton` component & story
  -  `weight`, `font-size` would inherit from parent
  - easy to use with in paragraph with other words
- change `text/paragraph` to `p` tag

# Dependency
N/A
