### PR TITLE
chore(universal-header): try to fix storybook deployment failure

### DIFF
--- a/packages/universal-header/.storybook/main.js
+++ b/packages/universal-header/.storybook/main.js
@@ -26,7 +26,7 @@ module.exports = {
       __dirname,
       '../../core/src/'
     )
-    config.resolve.alias['@twreporter/redux/lib'] = path.resolve(
+    config.resolve.alias['@twreporter/redux'] = path.resolve(
       __dirname,
       '../../redux/src/'
     )


### PR DESCRIPTION
## Issue
[Vercel build failure](https://vercel.com/twreporter-npm-packages/twreporter-npm-packages-universal-header/2P17cM3syiwfNsdJCojjLG68E7eK). 

## Bug Description
vercel 在部署 storybook 時，會把 twreporter-npm-packages 整個 repo clone 下來，跑 yarn install 安裝 dependencies。
但因為 twreporter-npm-packages 是 monorepo，npm workspaces 在安裝 packages/* 底下的 pkg 時，例如安裝 `packages/universal-header` 的 deps 時，npm workspaces 並不會真的安裝 `@twreporter/react-components` 和 `@twreporter/core`，反而是用 symlinks 的方式將 `node_modules/@twreporter/react-components` 指到 `packages/react-component` 目錄底下。

在 commit [feat: add useBookmark & useStore](https://github.com/twreporter/twreporter-npm-packages/commit/7fd48e521e659307b1b91a6b4acdfb4d0a2fd683) 之前，universal-header 雖然有標註 `@twreporter/react-components` 當作 deps，而 `@twreporter/react-components` 亦有標註 `@twreporter/redux` 當作 deps，但實際上，universal-header 在跑 storybook 時，程式碼並沒有真的用到 `@twreporter/redux`。
但 commit 進到 code base 後，universal-header 真的有用到 `@twreporter/redux`，然而，因為是 monorepo，所以 universal-header 並沒有真的安裝 `@twrerporter/redux`，當 `import twreporterRedux from '@twreporter/redux'` 執行時，其實是去 import `packages/redux` 底下的程式碼。所以實際會 import `packages/redux/package.json`  main 指定的 `lib/index.js` 檔案；但是 `packages/redux/lib` 資料夾需要 `make build` （或是 `yarn build`, `npm build`）才會產生，所以 storybook 部署時會找不到檔案，進而出現 module not found 的錯誤。

## Bug Fix
在 `.storybook/main.js` 中設定 `webpackFinal`，將`import @twreporter/redux` 改成 `import packages/redux/src/index.js`，這樣子就不會找不到檔案。


## 備註
比較好的解法，我覺得是讓 storybook 真的去下載 `@twreporter/redux`，而不是用 monorepo 裡面的 code。
但這個 PR 先解決燃眉之急。