### PR TITLE
fix: add margin between text and icon

### DIFF
--- a/packages/react-components/src/button/components/textButton.js
+++ b/packages/react-components/src/button/components/textButton.js
@@ -85,17 +85,9 @@ const TextButton = ({
       disabled={disabled}
       {...props}
     >
-      {size === Size.L ? (
-        <IconContainer isLeft={true}>{leftIconComponent}</IconContainer>
-      ) : (
-        leftIconComponent
-      )}
+      <IconContainer isLeft={true}>{leftIconComponent}</IconContainer>
       {textJSX}
-      {size === Size.L ? (
-        <IconContainer>{rightIconComponent}</IconContainer>
-      ) : (
-        rightIconComponent
-      )}
+      <IconContainer>{rightIconComponent}</IconContainer>
     </ButtonContainer>
   )
 }


### PR DESCRIPTION
# Issue
[[defect] card/general: text button size=small 時， icon 與 text 有 padding 4px](https://app.asana.com/0/0/1206371001801889/f)

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
