### PR TITLE
fix: use first category name in `category_set` for bookmark

### DIFF
--- a/packages/react-article-components/src/components/article-page.js
+++ b/packages/react-article-components/src/components/article-page.js
@@ -377,8 +377,7 @@ export default class Article extends PureComponent {
         _.get(post, 'og_image.resized_targets.mobile.url', ''),
       is_external: _.get(post, 'is_external', false),
       published_date: _.get(post, 'published_date', ''),
-      topicSlug: _.get(relatedTopic, 'slug', ''),
-      topicTitle: _.get(relatedTopic, 'title', ''),
+      category: _.get(post, 'category_set[0].category.name', ''),
     }
 
     const uiManager = new UIManager(post, relatedTopic)


### PR DESCRIPTION
# Issue
use first category name in `category_set` as bookmark category

# Notice
`twreporter-react` repo also has utils function to address this issue ([ref](https://github.com/twreporter/twreporter-react/blob/3424cbb32b2588eb4caf5712161dd2a555c04b40/src/utils/bookmark.js#L16))

# Dependency
N/A
