### PR TITLE
fix: add `white_0.9` to colorOpacity

### DIFF
--- a/packages/core/src/constants/color.js
+++ b/packages/core/src/constants/color.js
@@ -53,6 +53,7 @@ export const colorOpacity = Object.freeze({
   'white_0.2': 'rgba(255, 255, 255, 0.2)',
   'white_0.5': 'rgba(255, 255, 255, 0.5)',
   'white_0.8': 'rgba(255, 255, 255, 0.8)',
+  'white_0.9': 'rgba(255, 255, 255, 0.9)',
   'gray100_0.8': 'rgba(241, 241, 241, 0.8)',
   'black_0.1': 'rgba(0, 0, 0, 0.1)',
   'black_0.2': 'rgba(0, 0, 0, 0.2)',


### PR DESCRIPTION
# Issue
[[維運]  網站顏色盤點 : 主網站](https://app.asana.com/0/1203699264568808/1206157706155674/f)

# Notice
ref: [twreporter color](https://docs.google.com/spreadsheets/d/1-g8lEFgB4tbvXIunl0xOLfjsdlCghjohuvfiHZP0BGA/edit?usp=sharing)

# Dependency
N/A
