### PR TITLE
fix: add clickable prop for image

### DIFF
--- a/packages/react-article-components/src/components/body/image.js
+++ b/packages/react-article-components/src/components/body/image.js
@@ -42,6 +42,7 @@ export default class Image extends PureComponent {
             imgProps={imgProps}
             imageSet={[image.mobile, image.tablet, image.desktop, image.tiny]}
             defaultImage={image.mobile}
+            clickable={true}
             /* TODO: add sizes */
           />
           {caption ? <Caption itemprop="description">{caption}</Caption> : null}

--- a/packages/react-article-components/src/components/img-with-placeholder/index.js
+++ b/packages/react-article-components/src/components/img-with-placeholder/index.js
@@ -162,6 +162,7 @@ export default class Img extends React.PureComponent {
     ]),
     objectPosition: PropTypes.string,
     sizes: PropTypes.string.isRequired,
+    clickable: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -174,6 +175,7 @@ export default class Img extends React.PureComponent {
     placeholderNoBlur: false,
     noImgPlaceholder: false,
     sizes: '',
+    clickable: false,
   }
 
   constructor(props) {
@@ -269,12 +271,14 @@ export default class Img extends React.PureComponent {
       objectFit,
       objectPosition,
       sizes,
+      clickable,
     } = this.props
 
     const releaseBranch =
       this?.context?.releaseBranch || releaseBranchConsts.release
 
     const openFullScreen = () => {
+      if (!clickable) return
       this.setState({ showFullScreenImg: true })
       document.body.classList.add('disable-scroll')
     }

--- a/packages/react-article-components/src/components/leading/fullscreen.js
+++ b/packages/react-article-components/src/components/leading/fullscreen.js
@@ -182,6 +182,7 @@ export default class FullScreenLeading extends React.PureComponent {
           objectFit="cover"
           objectPostion="center center"
           sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, 2000px"
+          clickable={true}
         />
       </FigureBlock>
     )
@@ -197,6 +198,7 @@ export default class FullScreenLeading extends React.PureComponent {
               defaultImage={portraitPoster.mobile}
               objectFit="cover"
               objectPostion="center center"
+              clickable={true}
             />
           </FigureBlock>
         </DisplayOnPortrait>

--- a/packages/react-article-components/src/components/leading/normal.js
+++ b/packages/react-article-components/src/components/leading/normal.js
@@ -233,6 +233,7 @@ export default class NormalLeading extends React.PureComponent {
               imageSet={[poster.mobile, poster.tablet, poster.desktop]}
               defaultImage={poster.mobile}
               sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, 2000px"
+              clickable={true}
             />
             {figureCaption ? <FigCaption>{figureCaption}</FigCaption> : null}
           </Figure>

--- a/packages/react-article-components/src/components/leading/pink.js
+++ b/packages/react-article-components/src/components/leading/pink.js
@@ -229,6 +229,7 @@ export default class LeadingBlock extends PureComponent {
               objectFit="cover"
               objectPostion="center center"
               sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, 2000px"
+              clickable={true}
             />
           </FigureBlock>
         </ContentBlock>


### PR DESCRIPTION
# Issue
Add the `clickable` prop to prevent triggering the `disable-scroll` class.

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
