### PR TITLE
fix(rac): update embedded-code.js. Avoid `executeScript()` twice

### DIFF
--- a/packages/react-article-components/src/components/body/embedded-code.js
+++ b/packages/react-article-components/src/components/body/embedded-code.js
@@ -234,7 +234,8 @@ const WayPointWrapper = props => {
       onEnter={onEnter}
       onLeave={onLeave}
       fireOnRapidScroll={false}
-      topOffset="-150%"
+      topOffset={5}
+      bottomOffset="-100%"
     >
       <div>
         <EmbeddedCode {...props} ref={embedRef} />

--- a/packages/react-article-components/src/components/body/embedded-code.js
+++ b/packages/react-article-components/src/components/body/embedded-code.js
@@ -25,6 +25,7 @@ const _ = {
 const embedNamespace = {
   infogram: 'infogram',
   twreporter: '__twreporterEmbeddedData',
+  storyTellingReporter: '@story-telling-reporter',
 }
 
 export const Block = styled.div`
@@ -98,12 +99,24 @@ class EmbeddedCode extends React.PureComponent {
   }
 
   componentDidMount() {
-    // Delay loading infogram in loadEmbed()
-    if (!this._embeddedCodeWithoutScript?.includes(embedNamespace.infogram)) {
-      this.setState({ isLoaded: true }, this.executeScript)
-    }
+    //  !! WORKAROUND !!
+    //  After upgrading to react v18,
+    //  `EmbeddedCode` component becomes abnormal.
+    //  One case is that `EmbeddedCode` will `executeScript()` twice.
+    //  Therefore, the embedded code will generate duplicate contents.
+    //
+    //  To avoid `executeScript()` twice,
+    //  temporarily comment out the following condition.
+    //
+    //  Delay loading infogram in loadEmbed()
+    // if (!this._embeddedCodeWithoutScript?.includes(embedNamespace.infogram)) {
+    //   this.setState({ isLoaded: true }, this.executeScript)
+    // }
     // Deliberately set z-index for embeded from @twreporter
-    if (this._embeddedCode?.includes(embedNamespace.twreporter)) {
+    if (
+      this._embeddedCode?.includes(embedNamespace.twreporter) ||
+      this._embeddedCode?.includes(embedNamespace.storyTellingReporter)
+    ) {
       this.setState({ shouldEscalateZIndex: true })
     }
   }
@@ -221,7 +234,7 @@ const WayPointWrapper = props => {
       onEnter={onEnter}
       onLeave={onLeave}
       fireOnRapidScroll={false}
-      topOffset={5}
+      topOffset="-150%"
     >
       <div>
         <EmbeddedCode {...props} ref={embedRef} />


### PR DESCRIPTION
### Issue
slack msg: https://twreporter.slack.com/archives/C09N6TNN7/p1717123213877979

### Notice
After upgrading react to v18, `EmbeddedCode` component becomes abnormal. One case is that `EmbeddedCode` will `executeScript()` twice; therefore, it will generate duplicate contents.

This patch is a workaround to avoid `executeScript()` twice.

