### PR TITLE
fix: add missing `/` in url

### DIFF
--- a/packages/react-components/src/footer/constants/links.js
+++ b/packages/react-components/src/footer/constants/links.js
@@ -77,7 +77,7 @@ export const getLinksGroups = mainOrigin => {
       {
         slug: 'subcribe-email',
         text: '訂閱電子報',
-        to: `${mainOrigin}${entityPaths.account}email-subscription`,
+        to: `${mainOrigin}${entityPaths.account}/email-subscription`,
         target: '_blank',
         id: gtmId.newsletter,
       },


### PR DESCRIPTION
# Issue
[[維運] footer 超連結對象修改](https://app.asana.com/0/1203699264568808/1207466978658904/f)

# Dependency
N/A
