### PR TITLE
feat: add new sel-host font `tauhu-oo`

### DIFF
--- a/packages/core/src/constants/font.js
+++ b/packages/core/src/constants/font.js
@@ -4,6 +4,7 @@ const serif = 'serif'
 const robotoSlab = 'Roboto Slab'
 const notoSansTC = 'Noto Sans TC'
 const sansSerif = 'sans-serif'
+const tauhuOo = 'Tauhu Oo'
 
 const fonts = {
   merriweather,
@@ -12,6 +13,7 @@ const fonts = {
   robotoSlab,
   notoSansTC,
   sansSerif,
+  tauhuOo,
 }
 
 const fontWeight = {
@@ -22,7 +24,7 @@ const fontWeight = {
 
 const fontFamily = {
   title: `${merriweather}, ${sourceHanSerifTC}, ${serif}`,
-  default: `${robotoSlab}, ${notoSansTC}, ${sansSerif}`,
+  default: `${robotoSlab}, ${notoSansTC}, ${sansSerif}, ${tauhuOo}`,
   // use defaultFallback before ${notoSansTC} is fully loaded
   defaultFallback: `${robotoSlab}, ${sansSerif}`,
 }

--- a/packages/react-components/src/text/utils/webfonts.js
+++ b/packages/react-components/src/text/utils/webfonts.js
@@ -15,6 +15,7 @@ const fileExt = '.woff2'
 
 const gcsFontFolder = {
   [fonts.notoSansTC]: 'NotoSansTC',
+  [fonts.tauhuOo]: 'TauhuOo',
 }
 
 const fontWeightKeys = _.keys(fontWeight)
@@ -44,12 +45,16 @@ const fontFaces = {
     font: fonts.notoSansTC,
     folder: gcsFontFolder[fonts.notoSansTC],
   }),
+  [fonts.tauhuOo]: getFontFaces({
+    font: fonts.tauhuOo,
+    folder: gcsFontFolder[fonts.tauhuOo],
+  }),
 }
 
 let fontGCSFiles = []
 
-_.forEach(fontFaces, function(fontFace, font) {
-  _.forEach(fontWeightKeys, fontWeightKey => {
+_.forEach(fontFaces, function (fontFace, font) {
+  _.forEach(fontWeightKeys, (fontWeightKey) => {
     fontGCSFiles.push(
       `${baseGCSDir}${gcsFontFolder[font]}/${fontWeightKey}${fileExt}`
     )


### PR DESCRIPTION
# Issue
[[維運] 全站新增字體：豆腐烏體](https://app.asana.com/0/1203699264568808/1207840188252446/f)

# Note
- @nickhsine self-host font would be hosted in `https://www.twreporter.org/assets/font/`, thus we should delete the copy in `public.twreporter.org/fonts/` after release ([ref](https://github.com/twreporter/twreporter-npm-packages/blob/4fdc214fd7117dd0af4a323053dfdb2a77884247/packages/react-components/src/text/utils/webfonts.js#L13))

# Dependency
N/A
