### PR TITLE
fix: set loading false when embedded script loaded

### DIFF
--- a/packages/react-article-components/src/components/leading/embedded.js
+++ b/packages/react-article-components/src/components/leading/embedded.js
@@ -170,6 +170,11 @@ const Embedded = ({
     }
   }, [])
 
+  useEffect(() => {
+    window.addEventListener('load', handleIsLoaded, true)
+    return () => window.removeEventListener('load', handleIsLoaded, true)
+  }, [])
+
   return (
     <div>
       {isLoading ? (
@@ -183,7 +188,6 @@ const Embedded = ({
           <EmbeddedCodeComponent
             data={embeddedCode}
             showCaption={!captionText}
-            handleIsLoaded={handleIsLoaded}
           />
         </EmbeddedBlock>
       ) : null}


### PR DESCRIPTION
# Issue
[[維運] embeded 滿版新增 place holder 畫面](https://app.asana.com/0/1203699264568808/1208371474585818/f)

# Notice
`EmbeddedCode` component would fire `load` event on `window` after all script loaded.
and `handleIsLoaded` would be called when it start to load

# Dependency
N/A