### PR TITLE
fix: dispatch load event for inline script

### DIFF
--- a/packages/react-article-components/src/components/leading/embedded.js
+++ b/packages/react-article-components/src/components/leading/embedded.js
@@ -145,8 +145,8 @@ const Embedded = ({
     navigate.push(topicHref)
   }
 
-  const handleIsLoaded = () => {
-    // add timeout before hidding loading to prevent flashing
+  const handleFinishLoaded = () => {
+    // add timeout before hidding loading to prevent content shifting
     window.setTimeout(() => setIsLoading(false), 500)
   }
 
@@ -171,11 +171,6 @@ const Embedded = ({
     }
   }, [])
 
-  useEffect(() => {
-    window.addEventListener('load', handleIsLoaded, true)
-    return () => window.removeEventListener('load', handleIsLoaded, true)
-  }, [])
-
   return (
     <div>
       {isLoading ? (
@@ -189,6 +184,7 @@ const Embedded = ({
           <EmbeddedCodeComponent
             data={embeddedCode}
             showCaption={!captionText}
+            handleFinishLoaded={handleFinishLoaded}
           />
         </EmbeddedBlock>
       ) : null}


### PR DESCRIPTION
# Issue
[[維運] embeded 滿版新增 place holder 畫面](https://app.asana.com/0/1203699264568808/1208371474585818/f)

# Notice
- inline script would not fire `load` event after loaded, thus we need to dispatch `load` event mannually on the end of the inline script text
- also add `handleFinishLoaded` props for `Embedded` component to avoid misunderstanding of `handleLoaded` props

# Dependency
N/A
