### PR TITLE
fix: js error when loading embedded scripts

### DIFF
--- a/packages/react-article-components/src/components/body/embedded-code.js
+++ b/packages/react-article-components/src/components/body/embedded-code.js
@@ -73,8 +73,7 @@ function dispatchWindowLoadEvent() {
 const dispatchInlineScriptLoadEvent = (scriptText) => {
   return `${scriptText}
     // Manually trigger the load event on the script itself
-    const loadEvent = new Event('load');
-    document.currentScript.dispatchEvent(loadEvent); // Dispatches load event on this script element
+    document.currentScript.dispatchEvent(new Event('load'));
   `
 }
 
@@ -91,6 +90,7 @@ class EmbeddedCode extends React.PureComponent {
     className: '',
     showCaption: true,
     handleIsLoaded: () => {},
+    handleFinishLoaded: () => {},
   }
 
   state = {


### PR DESCRIPTION
# Issue
[[hotfix] 使用 embedded 的文章無法多個顯示](https://app.asana.com/0/1203699264568808/1206138012362942/f)

# Notice
- fix 2 js error when loading embedded scripts
  - `hanldeFinishLoaded` is not a function
  - `loadEvent` has been declared

# Dependency
N/A
