### PR TITLE
Disable autofocus of SearchBar for keyboard-navigation friendly

### DIFF
--- a/packages/react-components/src/input/components/search-bar.js
+++ b/packages/react-components/src/input/components/search-bar.js
@@ -94,7 +94,7 @@ const SearchBar = ({
   onSearch = defaultFunc,
   onClose = defaultFunc,
   handleBlur = defaultFunc,
-  autofocus = true,
+  autofocus = false,
   widthType = WidthType.FIT,
   ...props
 }) => {

--- a/packages/react-components/src/input/stories/search-bar.stories.js
+++ b/packages/react-components/src/input/stories/search-bar.stories.js
@@ -16,7 +16,7 @@ export default {
   },
 }
 
-const onSearch = keyword => window?.alert(`search keyword: ${keyword}`)
+const onSearch = (keyword) => window?.alert(`search keyword: ${keyword}`)
 const onClose = () => window?.alert('click close !')
 export const searchBar = {
   args: {
@@ -25,7 +25,6 @@ export const searchBar = {
     releaseBranch: BRANCH.master,
     onSearch,
     onClose,
-    autofocus: false,
     widthType: SearchBar.WidthType.FIT,
   },
 }

--- a/packages/universal-header/src/components/icons.js
+++ b/packages/universal-header/src/components/icons.js
@@ -147,6 +147,7 @@ const SearchIcon = () => {
         <SearchBar
           placeholder="關鍵字搜尋"
           theme={theme}
+          autofocus={false}
           onClose={closeSearchBox}
           onSearch={onSearch}
         />


### PR DESCRIPTION
Hi, this PR tries to address an accessibility issue:

# Issue
I often visit twreporter site from shared links (mostly to Article pages), and notice that I can't use **Page Up/Down** or **Home/End** keys to scroll.

This only happens in first visited page, subsequent navigation works fine.

The cause is that "search" input in the header automatically gets focus and intercepts all keyboard input.

Even more frustratingly, sometimes scrolling works at first, but once the page fully loads, it suddenly jumped back to top, and such keys stop responding. (this PR doesn't resolve the jumping back behavior)

Clarification: I'm using Firefox. Chrome/Edge can response PageDown in this scenario, but still not Home/End.

# Notice
Most component consumers already set autofocus to `false`, but pages using `UniversalHeader` (e.g., Article) have `true`.
It can be safely turned off because the focus behavior is already handled by `handleClickSearch`.

# Dependency
None.
