### PR TITLE
fix(redux): declare test runner dependencies

### DIFF
--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -40,6 +40,9 @@
     "redux-thunk": "^3.1.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.15.5",
+    "babel-jest": "^24.8.0",
+    "jest": "^24.8.0",
     "nock": "^13.4.0",
     "redux-mock-store": "^1.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5838,11 +5838,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@twreporter/redux@workspace:packages/redux"
   dependencies:
+    "@babel/core": "npm:^7.15.5"
     "@reduxjs/toolkit": "npm:^2.2.5"
     "@twreporter/core": "npm:^1.28.0"
     axios: "npm:^0.19.0"
+    babel-jest: "npm:^24.8.0"
     es6-error: "npm:^4.0.2"
     humps: "npm:^0.6.0"
+    jest: "npm:^24.8.0"
     localforage: "npm:^1.7.3"
     lodash: "npm:^4.17.4"
     nock: "npm:^13.4.0"


### PR DESCRIPTION
## Summary
CircleCI failed while running `make test` because Lerna v9 executes `@twreporter/redux`'s package test script in a workspace context where the root `jest` binary is not available on PATH.

Build failure:
https://app.circleci.com/pipelines/github/twreporter/twreporter-npm-packages/4840/workflows/fccef20b-9518-4603-9983-13cba3a0c9fb/jobs/7105

Declare the test-time dependencies required by `@twreporter/redux` directly in its devDependencies:

- `jest` for the `test` script
- `babel-jest` for `custom-babel-jest.js`
- `@babel/core` for `babel-jest`'s peer dependency

This keeps the package test script self-contained and avoids relying on the root workspace's hoisted binaries.

