### PR TITLE
fix(redux): run jest tests serially

### DIFF
--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -10,7 +10,7 @@
     "build": "make build",
     "dev": "make dev",
     "prepublishOnly": "make build",
-    "test": "jest --config jest.config.js"
+    "test": "jest --config jest.config.js --runInBand"
   },
   "keywords": [
     "twreporter",


### PR DESCRIPTION
 ##  Summary

  Run `@twreporter/redux` Jest tests serially with `--runInBand`.

  ## Why

  CircleCI runs the test job on Node 24, while this repo still uses Jest 24 for the redux package tests. In CI, Jest starts successfully but can stop after worker startup warnings without  producing test results, while the same tests complete locally.

  Build failure:
  https://app.circleci.com/pipelines/github/twreporter/twreporter-npm-packages/4843/workflows/5d58ae07-3947-4ef2-8d03-304899f182aa/jobs/7110

  ## Changes

  - Add `--runInBand` to `@twreporter/redux`'s `test` script.
  - This makes the redux Jest suite run in a single process, avoiding CI worker pool fork/resource issues without changing test cases or upgrading Jest.

  ## Verification

  - `make changed-packages-unit-test`
  - `make test`