### PR TITLE
chore: sync yarn lockfile after prerelease bump

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5725,7 +5725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@twreporter/core@npm:^1.28.0, @twreporter/core@workspace:packages/core":
+"@twreporter/core@npm:^1.28.1-rc.0, @twreporter/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@twreporter/core@workspace:packages/core"
   dependencies:
@@ -5749,8 +5749,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@twreporter/index-page@workspace:packages/index-page"
   dependencies:
-    "@twreporter/core": "npm:^1.28.0"
-    "@twreporter/react-components": "npm:^9.11.0"
+    "@twreporter/core": "npm:^1.28.1-rc.0"
+    "@twreporter/react-components": "npm:^9.11.1-rc.0"
     lodash: "npm:^4.0.0"
     prop-types: "npm:^15.0.0"
     react: "npm:^18.2.0"
@@ -5769,10 +5769,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@twreporter/react-article-components@workspace:packages/react-article-components"
   dependencies:
-    "@twreporter/core": "npm:^1.28.0"
-    "@twreporter/react-components": "npm:^9.11.0"
-    "@twreporter/redux": "npm:^8.4.3"
-    "@twreporter/universal-header": "npm:^3.2.2"
+    "@twreporter/core": "npm:^1.28.1-rc.0"
+    "@twreporter/react-components": "npm:^9.11.1-rc.0"
+    "@twreporter/redux": "npm:^8.4.4-rc.0"
+    "@twreporter/universal-header": "npm:^3.2.3-rc.0"
     babel-loader: "npm:^8.0.6"
     howler: "npm:^2.2.3"
     html-webpack-plugin: "npm:^3.2.0"
@@ -5794,7 +5794,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@twreporter/react-components@npm:^9.11.0, @twreporter/react-components@workspace:packages/react-components":
+"@twreporter/react-components@npm:^9.11.1-rc.0, @twreporter/react-components@workspace:packages/react-components":
   version: 0.0.0-use.local
   resolution: "@twreporter/react-components@workspace:packages/react-components"
   dependencies:
@@ -5813,8 +5813,8 @@ __metadata:
     "@storybook/react": "npm:^8.1.11"
     "@storybook/react-webpack5": "npm:^8.1.11"
     "@storybook/test": "npm:^8.1.11"
-    "@twreporter/core": "npm:^1.28.0"
-    "@twreporter/redux": "npm:^8.4.3"
+    "@twreporter/core": "npm:^1.28.1-rc.0"
+    "@twreporter/redux": "npm:^8.4.4-rc.0"
     babel-loader: "npm:^8.2.4"
     chromatic: "npm:^6.5.4"
     fontfaceobserver-es: "npm:^3.3.3"
@@ -5834,13 +5834,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@twreporter/redux@npm:^8.4.3, @twreporter/redux@workspace:packages/redux":
+"@twreporter/redux@npm:^8.4.4-rc.0, @twreporter/redux@workspace:packages/redux":
   version: 0.0.0-use.local
   resolution: "@twreporter/redux@workspace:packages/redux"
   dependencies:
     "@babel/core": "npm:^7.15.5"
     "@reduxjs/toolkit": "npm:^2.2.5"
-    "@twreporter/core": "npm:^1.28.0"
+    "@twreporter/core": "npm:^1.28.1-rc.0"
     axios: "npm:^0.19.0"
     babel-jest: "npm:^24.8.0"
     es6-error: "npm:^4.0.2"
@@ -5859,7 +5859,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@twreporter/universal-header@npm:^3.2.2, @twreporter/universal-header@workspace:packages/universal-header":
+"@twreporter/universal-header@npm:^3.2.3-rc.0, @twreporter/universal-header@workspace:packages/universal-header":
   version: 0.0.0-use.local
   resolution: "@twreporter/universal-header@workspace:packages/universal-header"
   dependencies:
@@ -5879,8 +5879,8 @@ __metadata:
     "@storybook/react": "npm:^8.1.11"
     "@storybook/react-webpack5": "npm:^8.1.11"
     "@storybook/test": "npm:^8.1.11"
-    "@twreporter/core": "npm:^1.28.0"
-    "@twreporter/react-components": "npm:^9.11.0"
+    "@twreporter/core": "npm:^1.28.1-rc.0"
+    "@twreporter/react-components": "npm:^9.11.1-rc.0"
     babel-loader: "npm:^8.2.5"
     lodash: "npm:^4.17.11"
     prop-types: "npm:^15.6.2"


### PR DESCRIPTION
## Summary
The robot-generated `chore(prerelease): bump version` (commit f447c83) commit updated workspace package versions and internal dependency ranges, but did not include the corresponding `yarn.lock` changes.

Because the `version_and_publish` workflow runs `yarn install` with the `--immutable` option, Yarn rejects the install when package manifests and the lockfile are out of sync.

Update `yarn.lock` to match the prerelease package ranges so the publish jobs can install dependencies without modifying the lockfile.

Build failure: https://app.circleci.com/pipelines/github/twreporter/twreporter-npm-packages/4846/workflows/fadc5db4-0afd-4f3e-a9ba-97e6a6e9f75b/jobs/7117
